### PR TITLE
Setup Go backend module

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+    "log"
+    "net/http"
+
+    "github.com/go-chi/chi/v5"
+)
+
+func main() {
+    r := chi.NewRouter()
+
+    // rota simples de health-check
+    r.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+        w.Write([]byte("ok"))
+    })
+
+    log.Println("▶️  backend rodando em http://localhost:8080")
+    if err := http.ListenAndServe(":8080", r); err != nil {
+        log.Fatal(err)
+    }
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,0 +1,3 @@
+module github.com/smithl4b/rcm.backoffice
+
+go 1.23.8


### PR DESCRIPTION
## Summary
- initialize go module
- add chi router dependency (fetch fails offline but referenced)
- implement minimal HTTP server

## Testing
- `go build ./...` *(fails: no required module provides package github.com/go-chi/chi/v5)*

------
https://chatgpt.com/codex/tasks/task_e_68584ca278f0832b934779033a35d17f