### PR TITLE
Add docker-compose with backend, frontend and db

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,43 @@
+version: "3.9"
+
+services:
+  db:
+    image: postgres:16
+    container_name: rcm-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    ports:
+      - "5432:5432"
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+  backend:
+    build:
+      context: ../backend
+      dockerfile: Dockerfile      # criaremos depois
+    container_name: rcm-backend
+    depends_on:
+      - db
+    environment:
+      DB_DSN: "postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}?sslmode=disable"
+      PORT: 8080
+    ports:
+      - "8080:8080"
+
+  frontend:
+    build:
+      context: ../frontend
+      dockerfile: Dockerfile      # criaremos depois
+    container_name: rcm-frontend
+    depends_on:
+      - backend
+    ports:
+      - "3000:3000"
+    environment:
+      NODE_ENV: development
+
+volumes:
+  db_data:


### PR DESCRIPTION
## Summary
- add docker-compose template with db, backend and frontend

## Testing
- `cat infra/docker-compose.yml`

------
https://chatgpt.com/codex/tasks/task_e_68584d717004832b9d66258d53e2fa1a