### PR TITLE
Add Dockerfile for backend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,20 @@
+# --- build stage ---
+FROM golang:1.22-alpine AS builder
+WORKDIR /app
+
+# cache das dependências
+COPY go.mod go.sum ./
+RUN go mod download
+
+# cópia do restante do código
+COPY . .
+
+# build estático
+RUN CGO_ENABLED=0 GOOS=linux go build -o /server ./cmd/server
+
+# --- run stage ---
+FROM gcr.io/distroless/static
+COPY --from=builder /server /server
+ENV PORT=8080
+EXPOSE 8080
+CMD ["/server"]


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile in backend to build and run the Go server

## Testing
- `go test ./...` *(fails: no required module provides package github.com/go-chi/chi/v5)*

------
https://chatgpt.com/codex/tasks/task_e_68584e104c24832bb92b2f8a1770b168