### PR TITLE
Atualiza help e docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,9 +8,9 @@
 | Agente | Diretório / entrypoint | Responsabilidade principal |
 |--------|-----------------------|----------------------------|
 | **CodexAssistant** | – | Recebe prompts curtos e gera código ou shell-scripts conforme as convenções deste repositório. |
-| **BackendBuilder** | `backend/` – `make build` | Compilar o binário Go (multi-stage), rodar `go vet` e testes de unidade. |
-| **FrontendBuilder** | `frontend/` – `npm run build` | Gerar artefatos Next.js para produção e verificar ESLint/TypeScript. |
-| **DBMigrator** | `migration/` – comando `migrate` | Aplicar e versionar migrações SQL no PostgreSQL. |
+| **BackendBuilder** | `backend/` – `make build-be` | Compilar o binário Go (multi-stage), rodar `go vet` e testes de unidade. |
+| **FrontendBuilder** | `frontend/` – `make build-fe` | Gerar artefatos Next.js para produção e verificar ESLint/TypeScript. |
+| **DBMigrator** | `migrations/` – `make migrate-*` | Criar e aplicar migrações SQL no PostgreSQL. |
 | **Deployer** | `infra/docker-compose.yml` | Fazer `docker-compose pull && up -d` em staging/produção. |
 | **ObservabilityWatcher** | `infra/observability.yml` | Subir stack Prometheus/Grafana e validar dashboards. |
 | **BackupAgent** | `infra/cron/pg_dump.sh` | Executar backup diário do banco e enviar para bucket S3-compatível. |

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,11 @@ help:
 	@echo "  test       - go test ./..."
 	@echo "  lint       - go vet ./..."
 	@echo "  build      - docker-compose build"
+	@echo "  build-be   - build da imagem backend"
+	@echo "  build-fe   - build da imagem frontend"
+	@echo "  migrate-create - cria nova migration (name=...)"
+	@echo "  migrate-up - aplica todas as migrations"
+	@echo "  migrate-down - desfaz migrations (mnum=1)"
 
 dev: down up logs
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ tanto em desenvolvimento quanto em produção.
 - Docker + Docker Compose
 - Go 1.22 (para desenvolvimento backend)
 - Node 20 (para desenvolvimento frontend)
-- Make (opcional) para atalhos
+ - Make (opcional) para atalhos — rode `make help` para listar comandos
 
 ## Subir em desenvolvimento
 
@@ -32,7 +32,7 @@ docker-compose -f infra/docker-compose.yml up -d --build
 backend/   # código Go (cmd, internal, pkg)
 frontend/  # Next.js + Tailwind + HeadlessUI
 infra/     # docker-compose, observability
-migration/ # scripts SQL (golang-migrate)
+migrations/ # scripts SQL (golang-migrate)
 docs/      # documentação complementar
 ```
 
@@ -40,12 +40,15 @@ docs/      # documentação complementar
 
 ## Comandos úteis
 
-| Ação              | Comando                 |
-| ----------------- | ----------------------- |
-| Testes backend    | `go test ./...`         |
-| Lint frontend     | `npm run lint`          |
-| Build backend     | `make build` (em breve) |
-| Atualizar deps Go | `go get -u`             |
+| Ação               | Comando                                   |
+| ------------------ | ------------------------------------------ |
+| Testes backend     | `make test`                                |
+| Lint backend       | `make lint`                                |
+| Lint frontend      | `npm run lint`                             |
+| Build imagens      | `make build`                               |
+| Criar migration    | `make migrate-create name=exemplo`         |
+| Aplicar migrations | `make migrate-up`                          |
+| Desfazer migrations| `make migrate-down mnum=1`                 |
 
 ---
 


### PR DESCRIPTION
## Summary
- melhora lista de comandos do `make help`
- explica uso do `make help` no README
- documenta novos targets de build e migrations no README
- atualiza tabela de agentes
- corrige path da pasta `migrations`

## Testing
- `make help`
- `make test`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_6858870e79b4832ba98e4a4c7e0f7752