### PR TITLE
Add customer handler and route

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -1,22 +1,27 @@
 package main
 
 import (
-    "log"
-    "net/http"
+	"log"
+	"net/http"
 
-    "github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5"
+
+	"github.com/smithl4b/rcm.backoffice/internal/customer"
 )
 
 func main() {
-    r := chi.NewRouter()
+	r := chi.NewRouter()
 
-    // rota simples de health-check
-    r.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) {
-        w.Write([]byte("ok"))
-    })
+	// módulo Customers
+	customer.RegisterRoutes(r)
 
-    log.Println("▶️  backend rodando em http://localhost:8080")
-    if err := http.ListenAndServe(":8080", r); err != nil {
-        log.Fatal(err)
-    }
+	// rota simples de health-check
+	r.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte("ok"))
+	})
+
+	log.Println("▶️  backend rodando em http://localhost:8080")
+	if err := http.ListenAndServe(":8080", r); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/backend/internal/customer/handler.go
+++ b/backend/internal/customer/handler.go
@@ -1,0 +1,18 @@
+package customer
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// RegisterRoutes adiciona as rotas do módulo Customer.
+func RegisterRoutes(r chi.Router) {
+	r.Get("/customers", list)
+}
+
+func list(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode([]interface{}{}) // placeholder []
+}


### PR DESCRIPTION
## Summary
- add new customer module with basic handler
- register `/customers` route in server

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6858956923f4832bb935f509aa998d87