### PR TITLE
Implement customer repository

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -3,17 +3,31 @@ package main
 import (
 	"log"
 	"net/http"
+	"os"
+
+	_ "github.com/lib/pq"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/jmoiron/sqlx"
 
 	"github.com/smithl4b/rcm.backoffice/internal/customer"
 )
 
 func main() {
+
+	dsn := os.Getenv("DB_DSN")
+	db, err := sqlx.Open("postgres", dsn)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	repo := customer.NewPostgresRepository(db)
+
 	r := chi.NewRouter()
 
 	// módulo Customers
-	customer.RegisterRoutes(r)
+	customer.RegisterRoutes(r, repo)
 
 	// rota simples de health-check
 	r.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) {

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -3,3 +3,8 @@ module github.com/smithl4b/rcm.backoffice
 go 1.23.8
 
 require github.com/go-chi/chi/v5 v5.2.2
+
+require (
+	github.com/jmoiron/sqlx v1.4.0 // indirect
+	github.com/lib/pq v1.10.9 // indirect
+)

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,2 +1,9 @@
+filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
 github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
+github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
+github.com/jmoiron/sqlx v1.4.0 h1:1PLqN7S1UYp5t4SrVVnt4nUVNemrDAtxlulVe+Qgm3o=
+github.com/jmoiron/sqlx v1.4.0/go.mod h1:ZrZ7UsYB/weZdl2Bxg6jCRO9c3YHl8r3ahlKmRT4JLY=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=

--- a/backend/internal/customer/customer.go
+++ b/backend/internal/customer/customer.go
@@ -1,0 +1,29 @@
+package customer
+
+import (
+	"context"
+	"time"
+)
+
+// Customer representa um cliente da aplicacao.
+type Customer struct {
+	ID         string     `db:"id" json:"id"`
+	LegalName  string     `db:"legal_name" json:"legalName"`
+	TradeName  string     `db:"trade_name" json:"tradeName"`
+	DocumentID string     `db:"document_id" json:"documentID"`
+	Email      string     `db:"email" json:"email"`
+	Phone      string     `db:"phone" json:"phone"`
+	PromoterID *string    `db:"promoter_id" json:"promoterID,omitempty"`
+	CreatedAt  time.Time  `db:"created_at" json:"createdAt"`
+	UpdatedAt  time.Time  `db:"updated_at" json:"updatedAt"`
+	DeletedAt  *time.Time `db:"deleted_at" json:"deletedAt,omitempty"`
+}
+
+// Repository define operacoes de acesso ao armazenamento de clientes.
+type Repository interface {
+	FindAll(ctx context.Context) ([]Customer, error)
+	FindByID(ctx context.Context, id string) (Customer, error)
+	Create(ctx context.Context, c *Customer) error
+	Update(ctx context.Context, c *Customer) error
+	SoftDelete(ctx context.Context, id string) error
+}

--- a/backend/internal/customer/handler.go
+++ b/backend/internal/customer/handler.go
@@ -8,11 +8,21 @@ import (
 )
 
 // RegisterRoutes adiciona as rotas do módulo Customer.
-func RegisterRoutes(r chi.Router) {
-	r.Get("/customers", list)
+func RegisterRoutes(r chi.Router, repo Repository) {
+	h := handler{repo: repo}
+	r.Get("/customers", h.list)
 }
 
-func list(w http.ResponseWriter, _ *http.Request) {
+type handler struct {
+	repo Repository
+}
+
+func (h handler) list(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode([]interface{}{}) // placeholder []
+	customers, err := h.repo.FindAll(r.Context())
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	_ = json.NewEncoder(w).Encode(customers)
 }

--- a/backend/internal/customer/postgres_repository.go
+++ b/backend/internal/customer/postgres_repository.go
@@ -1,0 +1,66 @@
+package customer
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// PostgresRepository implementa Repository usando PostgreSQL.
+type PostgresRepository struct {
+	db *sqlx.DB
+}
+
+// NewPostgresRepository cria uma instancia de PostgresRepository.
+func NewPostgresRepository(db *sqlx.DB) *PostgresRepository {
+	return &PostgresRepository{db: db}
+}
+
+// FindAll retorna todos os clientes nao excluidos.
+func (r *PostgresRepository) FindAll(ctx context.Context) ([]Customer, error) {
+	customers := []Customer{}
+	const q = `SELECT * FROM customers WHERE deleted_at IS NULL`
+	if err := r.db.SelectContext(ctx, &customers, q); err != nil {
+		return nil, err
+	}
+	return customers, nil
+}
+
+// FindByID retorna um cliente pelo ID.
+func (r *PostgresRepository) FindByID(ctx context.Context, id string) (Customer, error) {
+	var c Customer
+	const q = `SELECT * FROM customers WHERE id = $1 AND deleted_at IS NULL`
+	if err := r.db.GetContext(ctx, &c, q, id); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return Customer{}, nil
+		}
+		return Customer{}, err
+	}
+	return c, nil
+}
+
+// Create insere um novo cliente.
+func (r *PostgresRepository) Create(ctx context.Context, c *Customer) error {
+	const q = `INSERT INTO customers (id, legal_name, trade_name, document_id, email, phone, promoter_id)
+               VALUES (:id, :legal_name, :trade_name, :document_id, :email, :phone, :promoter_id)`
+	_, err := r.db.NamedExecContext(ctx, q, c)
+	return err
+}
+
+// Update atualiza dados do cliente.
+func (r *PostgresRepository) Update(ctx context.Context, c *Customer) error {
+	const q = `UPDATE customers SET legal_name=:legal_name, trade_name=:trade_name, document_id=:document_id,
+                email=:email, phone=:phone, promoter_id=:promoter_id, updated_at=now()
+                WHERE id=:id`
+	_, err := r.db.NamedExecContext(ctx, q, c)
+	return err
+}
+
+// SoftDelete marca um cliente como removido.
+func (r *PostgresRepository) SoftDelete(ctx context.Context, id string) error {
+	const q = `UPDATE customers SET deleted_at=now() WHERE id=$1 AND deleted_at IS NULL`
+	_, err := r.db.ExecContext(ctx, q, id)
+	return err
+}


### PR DESCRIPTION
## Summary
- add Customer model and repository interface
- implement PostgresRepository with sqlx
- wire repository into HTTP handler
- open database in main and pass repository

## Testing
- `go vet ./...`
- `make backend` *(fails: cannot find main module)*

------
https://chatgpt.com/codex/tasks/task_e_685897ea53a8832b8c5a2931286de894