### PR TITLE
Add handler unit tests

### DIFF
--- a/backend/internal/customer/handler_test.go
+++ b/backend/internal/customer/handler_test.go
@@ -1,0 +1,107 @@
+package customer
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type fakeRepository struct {
+	customers []Customer
+}
+
+func (f *fakeRepository) FindAll(ctx context.Context) ([]Customer, error) {
+	return f.customers, nil
+}
+
+func (f *fakeRepository) FindByID(ctx context.Context, id string) (Customer, error) {
+	return Customer{}, nil
+}
+
+func (f *fakeRepository) Create(ctx context.Context, c *Customer, addresses []Address) error {
+	f.customers = append(f.customers, *c)
+	return nil
+}
+
+func (f *fakeRepository) Update(ctx context.Context, c *Customer, addresses []Address) error {
+	return nil
+}
+
+func (f *fakeRepository) SoftDelete(ctx context.Context, id string) error {
+	return nil
+}
+
+func setupRouter() *chi.Mux {
+	r := chi.NewRouter()
+	repo := &fakeRepository{}
+	RegisterRoutes(r, repo)
+	return r
+}
+
+func TestGetCustomersEmpty(t *testing.T) {
+	server := httptest.NewServer(setupRouter())
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/customers")
+	if err != nil {
+		t.Fatalf("GET /customers error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	var out []Customer
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if len(out) != 0 {
+		t.Fatalf("expected 0 customers, got %d", len(out))
+	}
+}
+
+func TestPostCustomersAndGet(t *testing.T) {
+	server := httptest.NewServer(setupRouter())
+	defer server.Close()
+
+	body := strings.NewReader(`{"legal_name":"ACME","document_id":"1","addresses":[{"address_type":"billing","street":"A","city":"X","state":"Y"}]}`)
+	resp, err := http.Post(server.URL+"/customers", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST /customers error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d", resp.StatusCode)
+	}
+
+	resp2, err := http.Get(server.URL + "/customers")
+	if err != nil {
+		t.Fatalf("GET /customers error: %v", err)
+	}
+	defer resp2.Body.Close()
+
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp2.StatusCode)
+	}
+
+	var out []Customer
+	if err := json.NewDecoder(resp2.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if len(out) != 1 {
+		t.Fatalf("expected 1 customer, got %d", len(out))
+	}
+
+	if out[0].LegalName != "ACME" || out[0].DocumentID != "1" {
+		t.Fatalf("unexpected customer data: %+v", out[0])
+	}
+}


### PR DESCRIPTION
## Summary
- add fake repository and helper router for tests
- cover Customer handler GET/POST routes

## Testing
- `go vet ./...`
- `go test ./internal/customer -v`


------
https://chatgpt.com/codex/tasks/task_e_68589ffdcb98832ba74f687086b5e806