### PR TITLE
Implement DELETE /customers/{id}

### DIFF
--- a/backend/internal/customer/handler.go
+++ b/backend/internal/customer/handler.go
@@ -18,6 +18,7 @@ func RegisterRoutes(r chi.Router, repo Repository) {
 	r.Get("/customers", h.list)
 	r.Post("/customers", h.create)
 	r.Put("/customers/{id}", h.update)
+	r.Delete("/customers/{id}", h.remove)
 }
 
 type handler struct {
@@ -154,5 +155,18 @@ func (h handler) update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h handler) remove(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := h.repo.SoftDelete(r.Context(), id); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/backend/internal/customer/handler_test.go
+++ b/backend/internal/customer/handler_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"database/sql"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -16,7 +17,9 @@ type fakeRepository struct {
 }
 
 func (f *fakeRepository) FindAll(ctx context.Context) ([]Customer, error) {
-	return f.customers, nil
+	out := make([]Customer, len(f.customers))
+	copy(out, f.customers)
+	return out, nil
 }
 
 func (f *fakeRepository) FindByID(ctx context.Context, id string) (Customer, error) {
@@ -33,7 +36,13 @@ func (f *fakeRepository) Update(ctx context.Context, c *Customer, addresses []Ad
 }
 
 func (f *fakeRepository) SoftDelete(ctx context.Context, id string) error {
-	return nil
+	for i, c := range f.customers {
+		if c.ID == id {
+			f.customers = append(f.customers[:i], f.customers[i+1:]...)
+			return nil
+		}
+	}
+	return sql.ErrNoRows
 }
 
 func setupRouter() *chi.Mux {
@@ -103,5 +112,47 @@ func TestPostCustomersAndGet(t *testing.T) {
 
 	if out[0].LegalName != "ACME" || out[0].DocumentID != "1" {
 		t.Fatalf("unexpected customer data: %+v", out[0])
+	}
+}
+
+func TestDeleteCustomer(t *testing.T) {
+	server := httptest.NewServer(setupRouter())
+	defer server.Close()
+
+	body := strings.NewReader(`{"legal_name":"ACME","document_id":"1","addresses":[{"address_type":"billing","street":"A","city":"X","state":"Y"}]}`)
+	resp, err := http.Post(server.URL+"/customers", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST /customers error: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d", resp.StatusCode)
+	}
+
+	id := strings.TrimPrefix(resp.Header.Get("Location"), "/customers/")
+	req, _ := http.NewRequest(http.MethodDelete, server.URL+"/customers/"+id, nil)
+	resp2, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE /customers error: %v", err)
+	}
+	resp2.Body.Close()
+	if resp2.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d", resp2.StatusCode)
+	}
+
+	resp3, err := http.Get(server.URL + "/customers")
+	if err != nil {
+		t.Fatalf("GET /customers error: %v", err)
+	}
+	defer resp3.Body.Close()
+	if resp3.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp3.StatusCode)
+	}
+	var out []Customer
+	if err := json.NewDecoder(resp3.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(out) != 0 {
+		t.Fatalf("expected 0 customers, got %d", len(out))
 	}
 }

--- a/backend/internal/customer/postgres_repository.go
+++ b/backend/internal/customer/postgres_repository.go
@@ -125,6 +125,16 @@ func (r *PostgresRepository) Update(ctx context.Context, c *Customer, addrs []Ad
 // SoftDelete marca um cliente como removido.
 func (r *PostgresRepository) SoftDelete(ctx context.Context, id string) error {
 	const q = `UPDATE customers SET deleted_at=now() WHERE id=$1 AND deleted_at IS NULL`
-	_, err := r.db.ExecContext(ctx, q, id)
-	return err
+	res, err := r.db.ExecContext(ctx, q, id)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary
- add DELETE route for customers
- implement repository SoftDelete with row check
- expose handler.remove for soft deletion
- extend fake repository and tests for delete support

## Testing
- `go test ./internal/customer -v`
- `go vet ./...`
- `curl -X DELETE http://localhost:8080/customers/01ARZ3NDEKTSV4RRFFQ69G5FAV -v` (fails without DB)

------
https://chatgpt.com/codex/tasks/task_e_6858a2232bfc832b98cd8f69301aab9f