### PR TITLE
Implement services module with REST endpoints

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jmoiron/sqlx"
 
 	"github.com/smithl4b/rcm.backoffice/internal/customer"
+	"github.com/smithl4b/rcm.backoffice/internal/service"
 )
 
 func main() {
@@ -22,12 +23,15 @@ func main() {
 	}
 	defer db.Close()
 
-	repo := customer.NewPostgresRepository(db)
+	customerRepo := customer.NewPostgresRepository(db)
+	serviceRepo := service.NewPostgresRepository(db)
 
 	r := chi.NewRouter()
 
 	// módulo Customers
-	customer.RegisterRoutes(r, repo)
+	customer.RegisterRoutes(r, customerRepo)
+	// módulo Services
+	service.RegisterRoutes(r, serviceRepo)
 
 	// rota simples de health-check
 	r.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) {

--- a/backend/internal/service/handler.go
+++ b/backend/internal/service/handler.go
@@ -1,0 +1,74 @@
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-playground/validator/v10"
+	"github.com/oklog/ulid/v2"
+)
+
+// RegisterRoutes adiciona as rotas do modulo Service.
+func RegisterRoutes(r chi.Router, repo Repository) {
+	h := handler{repo: repo, validate: validator.New()}
+	r.Get("/services", h.list)
+	r.Post("/services", h.create)
+}
+
+type handler struct {
+	repo     Repository
+	validate *validator.Validate
+}
+
+type createServiceInput struct {
+	Name        string  `json:"name" validate:"required"`
+	Description string  `json:"description"`
+	BasePrice   float64 `json:"base_price" validate:"gte=0"`
+	IsActive    bool    `json:"is_active"`
+}
+
+func (h handler) list(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	services, err := h.repo.FindAll(r.Context())
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	_ = json.NewEncoder(w).Encode(services)
+}
+
+func (h handler) create(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	var in createServiceInput
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		return
+	}
+	if err := h.validate.Struct(in); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+
+	s := Service{
+		ID:          ulid.Make().String(),
+		Name:        in.Name,
+		Description: in.Description,
+		BasePrice:   in.BasePrice,
+		IsActive:    in.IsActive,
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+
+	if err := h.repo.Create(r.Context(), &s); err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Location", "/services/"+s.ID)
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(s)
+}

--- a/backend/internal/service/handler_test.go
+++ b/backend/internal/service/handler_test.go
@@ -1,0 +1,83 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type fakeRepository struct {
+	services []Service
+}
+
+func (f *fakeRepository) FindAll(ctx context.Context) ([]Service, error) {
+	out := make([]Service, len(f.services))
+	copy(out, f.services)
+	return out, nil
+}
+
+func (f *fakeRepository) Create(ctx context.Context, s *Service) error {
+	f.services = append(f.services, *s)
+	return nil
+}
+
+func setupRouter() *chi.Mux {
+	r := chi.NewRouter()
+	repo := &fakeRepository{}
+	RegisterRoutes(r, repo)
+	return r
+}
+
+func TestGetServicesEmpty(t *testing.T) {
+	server := httptest.NewServer(setupRouter())
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/services")
+	if err != nil {
+		t.Fatalf("GET /services error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	var out []Service
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if len(out) != 0 {
+		t.Fatalf("expected 0 services, got %d", len(out))
+	}
+}
+
+func TestCreateService(t *testing.T) {
+	server := httptest.NewServer(setupRouter())
+	defer server.Close()
+
+	body := strings.NewReader(`{"name":"Site Basico","base_price":1500}`)
+	resp, err := http.Post(server.URL+"/services", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST /services error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d", resp.StatusCode)
+	}
+
+	var svc Service
+	if err := json.NewDecoder(resp.Body).Decode(&svc); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if svc.Name != "Site Basico" || svc.BasePrice != 1500 {
+		t.Fatalf("unexpected service data: %+v", svc)
+	}
+}

--- a/backend/internal/service/model.go
+++ b/backend/internal/service/model.go
@@ -1,0 +1,15 @@
+package service
+
+import "time"
+
+// Service representa um servico comercializado pela aplicacao.
+type Service struct {
+	ID          string     `db:"id" json:"id"`
+	Name        string     `db:"name" json:"name"`
+	Description string     `db:"description" json:"description,omitempty"`
+	BasePrice   float64    `db:"base_price" json:"basePrice"`
+	IsActive    bool       `db:"is_active" json:"isActive"`
+	CreatedAt   time.Time  `db:"created_at" json:"createdAt"`
+	UpdatedAt   time.Time  `db:"updated_at" json:"updatedAt"`
+	DeletedAt   *time.Time `db:"deleted_at" json:"deletedAt,omitempty"`
+}

--- a/backend/internal/service/postgres_repository.go
+++ b/backend/internal/service/postgres_repository.go
@@ -1,0 +1,34 @@
+package service
+
+import (
+	"context"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// PostgresRepository implementa Repository usando PostgreSQL.
+type PostgresRepository struct {
+	db *sqlx.DB
+}
+
+// NewPostgresRepository cria uma instancia de PostgresRepository.
+func NewPostgresRepository(db *sqlx.DB) *PostgresRepository {
+	return &PostgresRepository{db: db}
+}
+
+// FindAll retorna todos os servicos ativos (nao excluidos).
+func (r *PostgresRepository) FindAll(ctx context.Context) ([]Service, error) {
+	services := []Service{}
+	const q = `SELECT * FROM services WHERE deleted_at IS NULL ORDER BY name`
+	if err := r.db.SelectContext(ctx, &services, q); err != nil {
+		return nil, err
+	}
+	return services, nil
+}
+
+// Create insere um novo servico.
+func (r *PostgresRepository) Create(ctx context.Context, s *Service) error {
+	const q = `INSERT INTO services (id, name, description, base_price, is_active) VALUES (:id, :name, :description, :base_price, :is_active)`
+	_, err := r.db.NamedExecContext(ctx, q, s)
+	return err
+}

--- a/backend/internal/service/service.go
+++ b/backend/internal/service/service.go
@@ -1,0 +1,9 @@
+package service
+
+import "context"
+
+// Repository define operacoes de acesso aos servicos.
+type Repository interface {
+	FindAll(ctx context.Context) ([]Service, error)
+	Create(ctx context.Context, s *Service) error
+}


### PR DESCRIPTION
## Summary
- add service module with model and repository
- create postgres implementation and HTTP handler
- expose service routes and repo in server main
- add unit tests for service handler

## Testing
- `go vet ./...`
- `go test ./internal/service -v`


------
https://chatgpt.com/codex/tasks/task_e_6858a79201b8832bb93d718f62b99a54