### PR TITLE
Implement service update and deletion

### DIFF
--- a/backend/internal/service/handler_test.go
+++ b/backend/internal/service/handler_test.go
@@ -2,11 +2,13 @@ package service
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -16,14 +18,48 @@ type fakeRepository struct {
 }
 
 func (f *fakeRepository) FindAll(ctx context.Context) ([]Service, error) {
-	out := make([]Service, len(f.services))
-	copy(out, f.services)
+	out := make([]Service, 0, len(f.services))
+	for _, s := range f.services {
+		if s.DeletedAt == nil {
+			out = append(out, s)
+		}
+	}
 	return out, nil
 }
 
 func (f *fakeRepository) Create(ctx context.Context, s *Service) error {
 	f.services = append(f.services, *s)
 	return nil
+}
+
+func (f *fakeRepository) Update(ctx context.Context, s *Service) error {
+	for i, svc := range f.services {
+		if svc.ID == s.ID {
+			svc.Name = s.Name
+			svc.Description = s.Description
+			svc.BasePrice = s.BasePrice
+			svc.IsActive = s.IsActive
+			svc.UpdatedAt = s.UpdatedAt
+			f.services[i] = svc
+			return nil
+		}
+	}
+	return sql.ErrNoRows
+}
+
+func (f *fakeRepository) SoftDelete(ctx context.Context, id string) error {
+	for i, svc := range f.services {
+		if svc.ID == id {
+			if svc.DeletedAt != nil {
+				return sql.ErrNoRows
+			}
+			now := time.Now()
+			svc.DeletedAt = &now
+			f.services[i] = svc
+			return nil
+		}
+	}
+	return sql.ErrNoRows
 }
 
 func setupRouter() *chi.Mux {
@@ -79,5 +115,110 @@ func TestCreateService(t *testing.T) {
 
 	if svc.Name != "Site Basico" || svc.BasePrice != 1500 {
 		t.Fatalf("unexpected service data: %+v", svc)
+	}
+}
+
+func TestUpdateService(t *testing.T) {
+	server := httptest.NewServer(setupRouter())
+	defer server.Close()
+
+	body := strings.NewReader(`{"name":"Site Basico","base_price":1500}`)
+	resp, err := http.Post(server.URL+"/services", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST /services error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d", resp.StatusCode)
+	}
+
+	var created Service
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode created: %v", err)
+	}
+
+	upd := strings.NewReader(`{"name":"Site Avancado","base_price":2000}`)
+	req, err := http.NewRequest(http.MethodPut, server.URL+"/services/"+created.ID, upd)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp2, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT /services/{id} error: %v", err)
+	}
+	defer resp2.Body.Close()
+
+	if resp2.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d", resp2.StatusCode)
+	}
+
+	resp3, err := http.Get(server.URL + "/services")
+	if err != nil {
+		t.Fatalf("GET /services error: %v", err)
+	}
+	defer resp3.Body.Close()
+
+	var list []Service
+	if err := json.NewDecoder(resp3.Body).Decode(&list); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+
+	if len(list) != 1 {
+		t.Fatalf("expected 1 service, got %d", len(list))
+	}
+	if list[0].Name != "Site Avancado" {
+		t.Fatalf("name not updated: %+v", list[0])
+	}
+}
+
+func TestDeleteService(t *testing.T) {
+	server := httptest.NewServer(setupRouter())
+	defer server.Close()
+
+	body := strings.NewReader(`{"name":"Site Basico","base_price":1500}`)
+	resp, err := http.Post(server.URL+"/services", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST /services error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d", resp.StatusCode)
+	}
+
+	var created Service
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode created: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, server.URL+"/services/"+created.ID, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp2, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE /services/{id} error: %v", err)
+	}
+	defer resp2.Body.Close()
+
+	if resp2.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d", resp2.StatusCode)
+	}
+
+	resp3, err := http.Get(server.URL + "/services")
+	if err != nil {
+		t.Fatalf("GET /services error: %v", err)
+	}
+	defer resp3.Body.Close()
+
+	var list []Service
+	if err := json.NewDecoder(resp3.Body).Decode(&list); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+
+	if len(list) != 0 {
+		t.Fatalf("expected 0 services, got %d", len(list))
 	}
 }

--- a/backend/internal/service/postgres_repository.go
+++ b/backend/internal/service/postgres_repository.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/jmoiron/sqlx"
 )
@@ -31,4 +32,38 @@ func (r *PostgresRepository) Create(ctx context.Context, s *Service) error {
 	const q = `INSERT INTO services (id, name, description, base_price, is_active) VALUES (:id, :name, :description, :base_price, :is_active)`
 	_, err := r.db.NamedExecContext(ctx, q, s)
 	return err
+}
+
+// Update atualiza um servico existente.
+func (r *PostgresRepository) Update(ctx context.Context, s *Service) error {
+	const q = `UPDATE services SET name=:name, description=:description, base_price=:base_price, is_active=:is_active, updated_at=now() WHERE id=:id AND deleted_at IS NULL`
+	res, err := r.db.NamedExecContext(ctx, q, s)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+// SoftDelete marca um servico como removido.
+func (r *PostgresRepository) SoftDelete(ctx context.Context, id string) error {
+	const q = `UPDATE services SET deleted_at=now() WHERE id=$1 AND deleted_at IS NULL`
+	res, err := r.db.ExecContext(ctx, q, id)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
 }

--- a/backend/internal/service/service.go
+++ b/backend/internal/service/service.go
@@ -6,4 +6,6 @@ import "context"
 type Repository interface {
 	FindAll(ctx context.Context) ([]Service, error)
 	Create(ctx context.Context, s *Service) error
+	Update(ctx context.Context, s *Service) error
+	SoftDelete(ctx context.Context, id string) error
 }


### PR DESCRIPTION
## Summary
- add update and soft delete methods to service repository
- expose PUT and DELETE endpoints for services
- add UpdateServiceInput and implement handlers
- cover update and delete paths with tests

## Testing
- `go vet ./...`
- `go test ./internal/service -v`


------
https://chatgpt.com/codex/tasks/task_e_6858a8d58758832bba3672ba2de360b3