### PR TITLE
Add promoters module

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jmoiron/sqlx"
 
 	"github.com/smithl4b/rcm.backoffice/internal/customer"
+	"github.com/smithl4b/rcm.backoffice/internal/promoter"
 	"github.com/smithl4b/rcm.backoffice/internal/service"
 )
 
@@ -25,6 +26,7 @@ func main() {
 
 	customerRepo := customer.NewPostgresRepository(db)
 	serviceRepo := service.NewPostgresRepository(db)
+	promoterRepo := promoter.NewPostgresRepository(db)
 
 	r := chi.NewRouter()
 
@@ -32,6 +34,8 @@ func main() {
 	customer.RegisterRoutes(r, customerRepo)
 	// módulo Services
 	service.RegisterRoutes(r, serviceRepo)
+	// módulo Promoters
+	promoter.RegisterRoutes(r, promoterRepo)
 
 	// rota simples de health-check
 	r.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) {

--- a/backend/internal/promoter/handler.go
+++ b/backend/internal/promoter/handler.go
@@ -1,0 +1,76 @@
+package promoter
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-playground/validator/v10"
+	"github.com/oklog/ulid/v2"
+)
+
+// RegisterRoutes adiciona as rotas do módulo Promoter.
+func RegisterRoutes(r chi.Router, repo Repository) {
+	h := handler{repo: repo, validate: validator.New()}
+	r.Get("/promoters", h.list)
+	r.Post("/promoters", h.create)
+}
+
+type handler struct {
+	repo     Repository
+	validate *validator.Validate
+}
+
+type createPromoterInput struct {
+	FullName    string          `json:"full_name" validate:"required"`
+	Email       string          `json:"email" validate:"omitempty,email"`
+	Phone       string          `json:"phone"`
+	DocumentID  string          `json:"document_id"`
+	BankAccount json.RawMessage `json:"bank_account"`
+}
+
+func (h handler) list(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	promoters, err := h.repo.FindAll(r.Context())
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	_ = json.NewEncoder(w).Encode(promoters)
+}
+
+func (h handler) create(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	var in createPromoterInput
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		return
+	}
+	if err := h.validate.Struct(in); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+
+	p := Promoter{
+		ID:          ulid.Make().String(),
+		FullName:    in.FullName,
+		Email:       in.Email,
+		Phone:       in.Phone,
+		DocumentID:  in.DocumentID,
+		BankAccount: in.BankAccount,
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+
+	if err := h.repo.Create(r.Context(), &p); err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Location", "/promoters/"+p.ID)
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(p)
+}

--- a/backend/internal/promoter/handler_test.go
+++ b/backend/internal/promoter/handler_test.go
@@ -1,0 +1,87 @@
+package promoter
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type fakeRepository struct {
+	promoters []Promoter
+}
+
+func (f *fakeRepository) FindAll(ctx context.Context) ([]Promoter, error) {
+	out := make([]Promoter, 0, len(f.promoters))
+	for _, p := range f.promoters {
+		if p.DeletedAt == nil {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeRepository) Create(ctx context.Context, p *Promoter) error {
+	f.promoters = append(f.promoters, *p)
+	return nil
+}
+
+func setupRouter() *chi.Mux {
+	r := chi.NewRouter()
+	repo := &fakeRepository{}
+	RegisterRoutes(r, repo)
+	return r
+}
+
+func TestGetPromotersEmpty(t *testing.T) {
+	server := httptest.NewServer(setupRouter())
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/promoters")
+	if err != nil {
+		t.Fatalf("GET /promoters error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	var out []Promoter
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if len(out) != 0 {
+		t.Fatalf("expected 0 promoters, got %d", len(out))
+	}
+}
+
+func TestCreatePromoter(t *testing.T) {
+	server := httptest.NewServer(setupRouter())
+	defer server.Close()
+
+	body := strings.NewReader(`{"full_name":"Joao","email":"joao@ex.com"}`)
+	resp, err := http.Post(server.URL+"/promoters", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST /promoters error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d", resp.StatusCode)
+	}
+
+	var p Promoter
+	if err := json.NewDecoder(resp.Body).Decode(&p); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if p.FullName != "Joao" || p.Email != "joao@ex.com" {
+		t.Fatalf("unexpected promoter data: %+v", p)
+	}
+}

--- a/backend/internal/promoter/model.go
+++ b/backend/internal/promoter/model.go
@@ -1,0 +1,19 @@
+package promoter
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// Promoter representa um divulgador de serviços.
+type Promoter struct {
+	ID          string          `db:"id" json:"id"`
+	FullName    string          `db:"full_name" json:"fullName"`
+	Email       string          `db:"email" json:"email,omitempty"`
+	Phone       string          `db:"phone" json:"phone,omitempty"`
+	DocumentID  string          `db:"document_id" json:"documentID,omitempty"`
+	BankAccount json.RawMessage `db:"bank_account" json:"bankAccount,omitempty"`
+	CreatedAt   time.Time       `db:"created_at" json:"createdAt"`
+	UpdatedAt   time.Time       `db:"updated_at" json:"updatedAt"`
+	DeletedAt   *time.Time      `db:"deleted_at" json:"deletedAt,omitempty"`
+}

--- a/backend/internal/promoter/postgres_repository.go
+++ b/backend/internal/promoter/postgres_repository.go
@@ -1,0 +1,34 @@
+package promoter
+
+import (
+	"context"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// PostgresRepository implementa Repository usando PostgreSQL.
+type PostgresRepository struct {
+	db *sqlx.DB
+}
+
+// NewPostgresRepository cria uma instancia de PostgresRepository.
+func NewPostgresRepository(db *sqlx.DB) *PostgresRepository {
+	return &PostgresRepository{db: db}
+}
+
+// FindAll retorna todos os promotores nao excluidos.
+func (r *PostgresRepository) FindAll(ctx context.Context) ([]Promoter, error) {
+	promoters := []Promoter{}
+	const q = `SELECT * FROM promoters WHERE deleted_at IS NULL ORDER BY full_name`
+	if err := r.db.SelectContext(ctx, &promoters, q); err != nil {
+		return nil, err
+	}
+	return promoters, nil
+}
+
+// Create insere um novo promotor.
+func (r *PostgresRepository) Create(ctx context.Context, p *Promoter) error {
+	const q = `INSERT INTO promoters (id, full_name, email, phone, document_id, bank_account) VALUES (:id, :full_name, :email, :phone, :document_id, :bank_account)`
+	_, err := r.db.NamedExecContext(ctx, q, p)
+	return err
+}

--- a/backend/internal/promoter/promoter.go
+++ b/backend/internal/promoter/promoter.go
@@ -1,0 +1,9 @@
+package promoter
+
+import "context"
+
+// Repository define operações para armazenamento de promotores.
+type Repository interface {
+	FindAll(ctx context.Context) ([]Promoter, error)
+	Create(ctx context.Context, p *Promoter) error
+}


### PR DESCRIPTION
## Summary
- add promoter model and repository interface
- implement Postgres repository and handlers
- wire up promoters in main server
- test GET and POST promoters endpoints

## Testing
- `go vet ./...`
- `go test ./internal/promoter -v`
- `curl -X POST http://localhost:8080/promoters -H "Content-Type: application/json" -d '{"full_name":"João Silva","email":"joao@ex.com"}'` *(fails: couldn't connect)*

------
https://chatgpt.com/codex/tasks/task_e_6858aa96649c832ba9a1e6d75cd17d2a