### PR TITLE
Implement Update and Delete for promoters

### DIFF
--- a/backend/internal/promoter/handler.go
+++ b/backend/internal/promoter/handler.go
@@ -1,7 +1,9 @@
 package promoter
 
 import (
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"time"
 
@@ -15,6 +17,8 @@ func RegisterRoutes(r chi.Router, repo Repository) {
 	h := handler{repo: repo, validate: validator.New()}
 	r.Get("/promoters", h.list)
 	r.Post("/promoters", h.create)
+	r.Put("/promoters/{id}", h.update)
+	r.Delete("/promoters/{id}", h.remove)
 }
 
 type handler struct {
@@ -23,6 +27,15 @@ type handler struct {
 }
 
 type createPromoterInput struct {
+	FullName    string          `json:"full_name" validate:"required"`
+	Email       string          `json:"email" validate:"omitempty,email"`
+	Phone       string          `json:"phone"`
+	DocumentID  string          `json:"document_id"`
+	BankAccount json.RawMessage `json:"bank_account"`
+}
+
+// UpdatePromoterInput define o payload para atualização de promotores.
+type UpdatePromoterInput struct {
 	FullName    string          `json:"full_name" validate:"required"`
 	Email       string          `json:"email" validate:"omitempty,email"`
 	Phone       string          `json:"phone"`
@@ -73,4 +86,55 @@ func (h handler) create(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Location", "/promoters/"+p.ID)
 	w.WriteHeader(http.StatusCreated)
 	_ = json.NewEncoder(w).Encode(p)
+}
+
+func (h handler) update(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	id := chi.URLParam(r, "id")
+
+	var in UpdatePromoterInput
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		return
+	}
+	if err := h.validate.Struct(in); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+
+	p := Promoter{
+		ID:          id,
+		FullName:    in.FullName,
+		Email:       in.Email,
+		Phone:       in.Phone,
+		DocumentID:  in.DocumentID,
+		BankAccount: in.BankAccount,
+		UpdatedAt:   time.Now(),
+	}
+
+	if err := h.repo.Update(r.Context(), &p); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h handler) remove(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := h.repo.SoftDelete(r.Context(), id); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/backend/internal/promoter/handler_test.go
+++ b/backend/internal/promoter/handler_test.go
@@ -2,11 +2,13 @@ package promoter
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -28,6 +30,37 @@ func (f *fakeRepository) FindAll(ctx context.Context) ([]Promoter, error) {
 func (f *fakeRepository) Create(ctx context.Context, p *Promoter) error {
 	f.promoters = append(f.promoters, *p)
 	return nil
+}
+
+func (f *fakeRepository) Update(ctx context.Context, p *Promoter) error {
+	for i, pr := range f.promoters {
+		if pr.ID == p.ID {
+			pr.FullName = p.FullName
+			pr.Email = p.Email
+			pr.Phone = p.Phone
+			pr.DocumentID = p.DocumentID
+			pr.BankAccount = p.BankAccount
+			pr.UpdatedAt = p.UpdatedAt
+			f.promoters[i] = pr
+			return nil
+		}
+	}
+	return sql.ErrNoRows
+}
+
+func (f *fakeRepository) SoftDelete(ctx context.Context, id string) error {
+	for i, pr := range f.promoters {
+		if pr.ID == id {
+			if pr.DeletedAt != nil {
+				return sql.ErrNoRows
+			}
+			now := time.Now()
+			pr.DeletedAt = &now
+			f.promoters[i] = pr
+			return nil
+		}
+	}
+	return sql.ErrNoRows
 }
 
 func setupRouter() *chi.Mux {
@@ -83,5 +116,110 @@ func TestCreatePromoter(t *testing.T) {
 
 	if p.FullName != "Joao" || p.Email != "joao@ex.com" {
 		t.Fatalf("unexpected promoter data: %+v", p)
+	}
+}
+
+func TestUpdatePromoter(t *testing.T) {
+	server := httptest.NewServer(setupRouter())
+	defer server.Close()
+
+	body := strings.NewReader(`{"full_name":"Joao"}`)
+	resp, err := http.Post(server.URL+"/promoters", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST /promoters error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d", resp.StatusCode)
+	}
+
+	var created Promoter
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode created: %v", err)
+	}
+
+	upd := strings.NewReader(`{"full_name":"Maria"}`)
+	req, err := http.NewRequest(http.MethodPut, server.URL+"/promoters/"+created.ID, upd)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp2, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT /promoters/{id} error: %v", err)
+	}
+	defer resp2.Body.Close()
+
+	if resp2.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d", resp2.StatusCode)
+	}
+
+	resp3, err := http.Get(server.URL + "/promoters")
+	if err != nil {
+		t.Fatalf("GET /promoters error: %v", err)
+	}
+	defer resp3.Body.Close()
+
+	var list []Promoter
+	if err := json.NewDecoder(resp3.Body).Decode(&list); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+
+	if len(list) != 1 {
+		t.Fatalf("expected 1 promoter, got %d", len(list))
+	}
+	if list[0].FullName != "Maria" {
+		t.Fatalf("name not updated: %+v", list[0])
+	}
+}
+
+func TestDeletePromoter(t *testing.T) {
+	server := httptest.NewServer(setupRouter())
+	defer server.Close()
+
+	body := strings.NewReader(`{"full_name":"Joao"}`)
+	resp, err := http.Post(server.URL+"/promoters", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST /promoters error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d", resp.StatusCode)
+	}
+
+	var created Promoter
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode created: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, server.URL+"/promoters/"+created.ID, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp2, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE /promoters/{id} error: %v", err)
+	}
+	defer resp2.Body.Close()
+
+	if resp2.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d", resp2.StatusCode)
+	}
+
+	resp3, err := http.Get(server.URL + "/promoters")
+	if err != nil {
+		t.Fatalf("GET /promoters error: %v", err)
+	}
+	defer resp3.Body.Close()
+
+	var list []Promoter
+	if err := json.NewDecoder(resp3.Body).Decode(&list); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+
+	if len(list) != 0 {
+		t.Fatalf("expected 0 promoters, got %d", len(list))
 	}
 }

--- a/backend/internal/promoter/postgres_repository.go
+++ b/backend/internal/promoter/postgres_repository.go
@@ -2,6 +2,7 @@ package promoter
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/jmoiron/sqlx"
 )
@@ -31,4 +32,38 @@ func (r *PostgresRepository) Create(ctx context.Context, p *Promoter) error {
 	const q = `INSERT INTO promoters (id, full_name, email, phone, document_id, bank_account) VALUES (:id, :full_name, :email, :phone, :document_id, :bank_account)`
 	_, err := r.db.NamedExecContext(ctx, q, p)
 	return err
+}
+
+// Update atualiza um promotor existente.
+func (r *PostgresRepository) Update(ctx context.Context, p *Promoter) error {
+	const q = `UPDATE promoters SET full_name=:full_name, email=:email, phone=:phone, document_id=:document_id, bank_account=:bank_account, updated_at=now() WHERE id=:id AND deleted_at IS NULL`
+	res, err := r.db.NamedExecContext(ctx, q, p)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+// SoftDelete marca um promotor como removido.
+func (r *PostgresRepository) SoftDelete(ctx context.Context, id string) error {
+	const q = `UPDATE promoters SET deleted_at=now() WHERE id=$1 AND deleted_at IS NULL`
+	res, err := r.db.ExecContext(ctx, q, id)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
 }

--- a/backend/internal/promoter/promoter.go
+++ b/backend/internal/promoter/promoter.go
@@ -6,4 +6,6 @@ import "context"
 type Repository interface {
 	FindAll(ctx context.Context) ([]Promoter, error)
 	Create(ctx context.Context, p *Promoter) error
+	Update(ctx context.Context, p *Promoter) error
+	SoftDelete(ctx context.Context, id string) error
 }


### PR DESCRIPTION
## Summary
- add UpdatePromoterInput and update/delete handlers
- extend promoter repository interface with Update and SoftDelete
- implement Update and SoftDelete in Postgres repository
- expand test fakeRepository and add update/delete tests

## Testing
- `go vet ./...`
- `go test ./internal/promoter -v`

------
https://chatgpt.com/codex/tasks/task_e_6858ad3bfd7c832b8880c823854e5672