### PR TITLE
Implement contract update and delete endpoints

### DIFF
--- a/backend/internal/contract/contract.go
+++ b/backend/internal/contract/contract.go
@@ -4,6 +4,8 @@ import "context"
 
 // Repository define operações para persistência de contratos.
 type Repository interface {
-	FindAll(ctx context.Context) ([]Contract, error)
-	Create(ctx context.Context, c *Contract) error
+        FindAll(ctx context.Context) ([]Contract, error)
+        Create(ctx context.Context, c *Contract) error
+       Update(ctx context.Context, c *Contract) error
+       SoftDelete(ctx context.Context, id string) error
 }

--- a/backend/internal/contract/handler_test.go
+++ b/backend/internal/contract/handler_test.go
@@ -1,17 +1,20 @@
 package contract
 
 import (
-	"context"
-	"encoding/json"
-	"github.com/go-chi/chi/v5"
-	"net/http"
-	"net/http/httptest"
-	"strings"
-	"testing"
+       "context"
+       "database/sql"
+       "encoding/json"
+       "net/http"
+       "net/http/httptest"
+       "strings"
+       "testing"
+       "time"
+
+       "github.com/go-chi/chi/v5"
 )
 
 type fakeRepository struct {
-	contracts []Contract
+        contracts []Contract
 }
 
 func (f *fakeRepository) FindAll(ctx context.Context) ([]Contract, error) {
@@ -25,8 +28,38 @@ func (f *fakeRepository) FindAll(ctx context.Context) ([]Contract, error) {
 }
 
 func (f *fakeRepository) Create(ctx context.Context, c *Contract) error {
-	f.contracts = append(f.contracts, *c)
-	return nil
+        f.contracts = append(f.contracts, *c)
+        return nil
+}
+
+func (f *fakeRepository) Update(ctx context.Context, c *Contract) error {
+       for i, ct := range f.contracts {
+               if ct.ID == c.ID {
+                       ct.ValueTotal = c.ValueTotal
+                       ct.StartDate = c.StartDate
+                       ct.EndDate = c.EndDate
+                       ct.Status = c.Status
+                       ct.UpdatedAt = c.UpdatedAt
+                       f.contracts[i] = ct
+                       return nil
+               }
+       }
+       return sql.ErrNoRows
+}
+
+func (f *fakeRepository) SoftDelete(ctx context.Context, id string) error {
+       for i, ct := range f.contracts {
+               if ct.ID == id {
+                       if ct.DeletedAt != nil {
+                               return sql.ErrNoRows
+                       }
+                       now := time.Now()
+                       ct.DeletedAt = &now
+                       f.contracts[i] = ct
+                       return nil
+               }
+       }
+       return sql.ErrNoRows
 }
 
 func setupRouter() *chi.Mux {
@@ -87,4 +120,102 @@ func TestCreateContract(t *testing.T) {
 	if c.StartDate.IsZero() {
 		t.Fatalf("start_date not set")
 	}
+}
+
+func TestUpdateContract(t *testing.T) {
+       server := httptest.NewServer(setupRouter())
+       defer server.Close()
+
+       body := strings.NewReader(`{"customer_id":"c1","service_id":"s1","value_total":1000,"start_date":"2025-07-01"}`)
+       resp, err := http.Post(server.URL+"/contracts", "application/json", body)
+       if err != nil {
+               t.Fatalf("POST /contracts error: %v", err)
+       }
+       defer resp.Body.Close()
+       if resp.StatusCode != http.StatusCreated {
+               t.Fatalf("expected status 201, got %d", resp.StatusCode)
+       }
+
+       var created Contract
+       if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+               t.Fatalf("decode created: %v", err)
+       }
+
+       upd := strings.NewReader(`{"value_total":2000,"start_date":"2025-07-01","status":"active"}`)
+       req, err := http.NewRequest(http.MethodPut, server.URL+"/contracts/"+created.ID, upd)
+       if err != nil {
+               t.Fatalf("new request: %v", err)
+       }
+       req.Header.Set("Content-Type", "application/json")
+       resp2, err := http.DefaultClient.Do(req)
+       if err != nil {
+               t.Fatalf("PUT /contracts/{id} error: %v", err)
+       }
+       defer resp2.Body.Close()
+       if resp2.StatusCode != http.StatusNoContent {
+               t.Fatalf("expected status 204, got %d", resp2.StatusCode)
+       }
+
+       resp3, err := http.Get(server.URL + "/contracts")
+       if err != nil {
+               t.Fatalf("GET /contracts error: %v", err)
+       }
+       defer resp3.Body.Close()
+
+       var list []Contract
+       if err := json.NewDecoder(resp3.Body).Decode(&list); err != nil {
+               t.Fatalf("decode list: %v", err)
+       }
+       if len(list) != 1 {
+               t.Fatalf("expected 1 contract, got %d", len(list))
+       }
+       if list[0].ValueTotal != 2000 {
+               t.Fatalf("value_total not updated: %+v", list[0])
+       }
+}
+
+func TestDeleteContract(t *testing.T) {
+       server := httptest.NewServer(setupRouter())
+       defer server.Close()
+
+       body := strings.NewReader(`{"customer_id":"c1","service_id":"s1","value_total":1000,"start_date":"2025-07-01"}`)
+       resp, err := http.Post(server.URL+"/contracts", "application/json", body)
+       if err != nil {
+               t.Fatalf("POST /contracts error: %v", err)
+       }
+       defer resp.Body.Close()
+       if resp.StatusCode != http.StatusCreated {
+               t.Fatalf("expected status 201, got %d", resp.StatusCode)
+       }
+       var created Contract
+       if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+               t.Fatalf("decode created: %v", err)
+       }
+
+       req, err := http.NewRequest(http.MethodDelete, server.URL+"/contracts/"+created.ID, nil)
+       if err != nil {
+               t.Fatalf("new request: %v", err)
+       }
+       resp2, err := http.DefaultClient.Do(req)
+       if err != nil {
+               t.Fatalf("DELETE /contracts/{id} error: %v", err)
+       }
+       defer resp2.Body.Close()
+       if resp2.StatusCode != http.StatusNoContent {
+               t.Fatalf("expected status 204, got %d", resp2.StatusCode)
+       }
+
+       resp3, err := http.Get(server.URL + "/contracts")
+       if err != nil {
+               t.Fatalf("GET /contracts error: %v", err)
+       }
+       defer resp3.Body.Close()
+
+       var list []Contract
+       if err := json.NewDecoder(resp3.Body).Decode(&list); err != nil {
+               t.Fatalf("decode list: %v", err)
+       }
+       if len(list) != 0 {
+               t.Fatalf("expected 0 contracts, got %d", len(list))
+       }
 }

--- a/backend/internal/contract/postgres_repository.go
+++ b/backend/internal/contract/postgres_repository.go
@@ -45,7 +45,41 @@ func (r *PostgresRepository) Create(ctx context.Context, c *Contract) error {
 		return err
 	}
 
-	const q = `INSERT INTO contracts (id, customer_id, service_id, promoter_id, value_total, start_date, end_date, status) VALUES (:id, :customer_id, :service_id, :promoter_id, :value_total, :start_date, :end_date, :status)`
-	_, err := r.db.NamedExecContext(ctx, q, c)
-	return err
+        const q = `INSERT INTO contracts (id, customer_id, service_id, promoter_id, value_total, start_date, end_date, status) VALUES (:id, :customer_id, :service_id, :promoter_id, :value_total, :start_date, :end_date, :status)`
+        _, err := r.db.NamedExecContext(ctx, q, c)
+        return err
+}
+
+// Update altera dados de um contrato existente.
+func (r *PostgresRepository) Update(ctx context.Context, c *Contract) error {
+       const q = `UPDATE contracts SET value_total=:value_total, start_date=:start_date, end_date=:end_date, status=:status, updated_at=now() WHERE id=:id AND deleted_at IS NULL`
+       res, err := r.db.NamedExecContext(ctx, q, c)
+       if err != nil {
+               return err
+       }
+       affected, err := res.RowsAffected()
+       if err != nil {
+               return err
+       }
+       if affected == 0 {
+               return sql.ErrNoRows
+       }
+       return nil
+}
+
+// SoftDelete marca um contrato como removido.
+func (r *PostgresRepository) SoftDelete(ctx context.Context, id string) error {
+       const q = `UPDATE contracts SET deleted_at=now() WHERE id=$1 AND deleted_at IS NULL`
+       res, err := r.db.ExecContext(ctx, q, id)
+       if err != nil {
+               return err
+       }
+       affected, err := res.RowsAffected()
+       if err != nil {
+               return err
+       }
+       if affected == 0 {
+               return sql.ErrNoRows
+       }
+       return nil
 }


### PR DESCRIPTION
## Summary
- add update and soft delete methods to contract repository
- expose PUT and DELETE `/contracts/{id}` routes
- implement handlers and validation logic
- extend fake repository and tests for update & delete

## Testing
- `go vet ./...`
- `go test ./backend/internal/contract -v`


------
https://chatgpt.com/codex/tasks/task_e_6858b3e18398832b938eec55110f93c3