### PR TITLE
Update AGENTS docs for gofmt instruction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,4 +26,5 @@
 6. **Revisão de código** – ao propor modificações em arquivos, analisar o trecho alterado para identificar possíveis melhorias ou riscos antes de aplicar a mudança.
 7. **Testes de unidade** – sempre criar e rodar testes unitários para qualquer alteração de código.
 8. **Formatação** – utilizar ferramentas de formatação (ex.: `gofmt`, `prettier`) para garantir a qualidade e consistência do código.
+9. **Gofmt obrigatório** – antes de realizar commits, execute `gofmt -w .` dentro do diretório `backend/` para manter o código Go devidamente formatado.
 


### PR DESCRIPTION
## Summary
- document a new rule to run `gofmt -w .` in the `backend/` folder before committing
- ensured no pre-commit hook remains

## Testing
- `ls -al .git/hooks | grep pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_6858b7edb41c832bbaf69b354e335390