### PR TITLE
Add finance module with receivable and commission endpoints

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/smithl4b/rcm.backoffice/internal/auth"
 	"github.com/smithl4b/rcm.backoffice/internal/contract"
 	"github.com/smithl4b/rcm.backoffice/internal/customer"
+	"github.com/smithl4b/rcm.backoffice/internal/finance"
 	"github.com/smithl4b/rcm.backoffice/internal/promoter"
 	"github.com/smithl4b/rcm.backoffice/internal/service"
 )
@@ -31,6 +32,7 @@ func main() {
 	serviceRepo := service.NewPostgresRepository(db)
 	promoterRepo := promoter.NewPostgresRepository(db)
 	contractRepo := contract.NewPostgresRepository(db)
+	financeRepo := finance.NewPostgresRepository(db)
 	authRepo := auth.NewPostgresRepository(db)
 	auditRepo := audit.NewPostgresRepository(db)
 	geoSvc := audit.NewHttpGeoService()
@@ -54,6 +56,7 @@ func main() {
 		service.RegisterRoutes(pr, serviceRepo)
 		promoter.RegisterRoutes(pr, promoterRepo)
 		contract.RegisterRoutes(pr, contractRepo)
+		finance.RegisterRoutes(pr, financeRepo)
 	})
 
 	// rota simples de health-check

--- a/backend/internal/finance/finance.go
+++ b/backend/internal/finance/finance.go
@@ -1,0 +1,22 @@
+package finance
+
+import (
+	"context"
+	"errors"
+)
+
+// Repository define operacoes para contas a receber e comissoes.
+type Repository interface {
+	ListReceivables(ctx context.Context, status string) ([]AccountReceivable, error)
+	MarkAsPaid(ctx context.Context, id string) error
+
+	ListCommissions(ctx context.Context, onlyPending bool) ([]Commission, error)
+	ApproveCommission(ctx context.Context, id string, approverID string) error
+}
+
+// Errors especificos
+
+var (
+	ErrAlreadyPaid     = errors.New("already paid")
+	ErrAlreadyApproved = errors.New("already approved")
+)

--- a/backend/internal/finance/handler.go
+++ b/backend/internal/finance/handler.go
@@ -1,0 +1,89 @@
+package finance
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/smithl4b/rcm.backoffice/internal/auth"
+)
+
+// RegisterRoutes adiciona as rotas do modulo Finance.
+func RegisterRoutes(r chi.Router, repo Repository) {
+	h := handler{repo: repo}
+	r.Route("/receivables", func(r chi.Router) {
+		r.Use(auth.RequireRole("finance"))
+		r.Get("/", h.listReceivables)
+		r.Put("/{id}/pay", h.markAsPaid)
+	})
+	r.Route("/commissions", func(r chi.Router) {
+		r.Use(auth.RequireRole("finance"))
+		r.Get("/", h.listCommissions)
+		r.Put("/{id}/approve", h.approveCommission)
+	})
+}
+
+type handler struct {
+	repo Repository
+}
+
+func (h handler) listReceivables(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	status := r.URL.Query().Get("status")
+	list, err := h.repo.ListReceivables(r.Context(), status)
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	_ = json.NewEncoder(w).Encode(list)
+}
+
+func (h handler) markAsPaid(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	err := h.repo.MarkAsPaid(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+		if errors.Is(err, ErrAlreadyPaid) {
+			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+			return
+		}
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h handler) listCommissions(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	pending := r.URL.Query().Get("pending") == "true"
+	list, err := h.repo.ListCommissions(r.Context(), pending)
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	_ = json.NewEncoder(w).Encode(list)
+}
+
+func (h handler) approveCommission(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	userID := auth.UserIDFromContext(r.Context())
+	err := h.repo.ApproveCommission(r.Context(), id, userID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+		if errors.Is(err, ErrAlreadyApproved) {
+			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+			return
+		}
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/backend/internal/finance/handler_test.go
+++ b/backend/internal/finance/handler_test.go
@@ -1,0 +1,163 @@
+package finance
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/smithl4b/rcm.backoffice/internal/auth"
+)
+
+type fakeRepository struct {
+	receivables []AccountReceivable
+	commissions []Commission
+}
+
+func (f *fakeRepository) ListReceivables(ctx context.Context, status string) ([]AccountReceivable, error) {
+	out := make([]AccountReceivable, 0)
+	for _, ar := range f.receivables {
+		if status == "" || ar.Status == status {
+			out = append(out, ar)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeRepository) MarkAsPaid(ctx context.Context, id string) error {
+	for i, ar := range f.receivables {
+		if ar.ID == id {
+			if ar.Status != "open" {
+				return ErrAlreadyPaid
+			}
+			ar.Status = "paid"
+			now := time.Now()
+			ar.PaidAt = &now
+			f.receivables[i] = ar
+			return nil
+		}
+	}
+	return sql.ErrNoRows
+}
+
+func (f *fakeRepository) ListCommissions(ctx context.Context, onlyPending bool) ([]Commission, error) {
+	out := make([]Commission, 0)
+	for _, c := range f.commissions {
+		if !onlyPending || !c.Approved {
+			out = append(out, c)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeRepository) ApproveCommission(ctx context.Context, id string, approverID string) error {
+	for i, c := range f.commissions {
+		if c.ID == id {
+			if c.Approved {
+				return ErrAlreadyApproved
+			}
+			c.Approved = true
+			c.ApprovedBy = approverID
+			now := time.Now()
+			c.ApprovedAt = &now
+			f.commissions[i] = c
+			return nil
+		}
+	}
+	return sql.ErrNoRows
+}
+
+func setupRouter(repo Repository) (*chi.Mux, string) {
+	os.Setenv("JWT_SECRET", "testsecret")
+	claims := jwt.MapClaims{"sub": "u1", "role": "finance", "exp": time.Now().Add(time.Hour).Unix()}
+	tokenStr, _ := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte("testsecret"))
+
+	r := chi.NewRouter()
+	r.Use(auth.AuthMiddleware)
+	RegisterRoutes(r, repo)
+	return r, tokenStr
+}
+
+func TestListReceivablesEmpty(t *testing.T) {
+	router, token := setupRouter(&fakeRepository{})
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, server.URL+"/receivables", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /receivables error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	var out []AccountReceivable
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(out) != 0 {
+		t.Fatalf("expected 0, got %d", len(out))
+	}
+}
+
+func TestMarkAsPaid(t *testing.T) {
+	repo := &fakeRepository{receivables: []AccountReceivable{{ID: "r1", Status: "open"}}}
+	router, token := setupRouter(repo)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	req, _ := http.NewRequest(http.MethodPut, server.URL+"/receivables/r1/pay", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT /receivables/{id}/pay error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d", resp.StatusCode)
+	}
+
+	if repo.receivables[0].Status != "paid" {
+		t.Fatalf("status not updated: %+v", repo.receivables[0])
+	}
+	if repo.receivables[0].PaidAt == nil {
+		t.Fatalf("paid_at not set")
+	}
+}
+
+func TestApproveCommission(t *testing.T) {
+	repo := &fakeRepository{commissions: []Commission{{ID: "c1"}}}
+	router, token := setupRouter(repo)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	req, _ := http.NewRequest(http.MethodPut, server.URL+"/commissions/c1/approve", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT /commissions/{id}/approve error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d", resp.StatusCode)
+	}
+
+	if !repo.commissions[0].Approved {
+		t.Fatalf("commission not approved")
+	}
+	if repo.commissions[0].ApprovedBy == "" {
+		t.Fatalf("approved_by empty")
+	}
+}

--- a/backend/internal/finance/model.go
+++ b/backend/internal/finance/model.go
@@ -1,0 +1,28 @@
+package finance
+
+import "time"
+
+// AccountReceivable representa um valor a receber de um contrato.
+type AccountReceivable struct {
+	ID         string     `db:"id" json:"id"`
+	ContractID string     `db:"contract_id" json:"contractID"`
+	DueDate    time.Time  `db:"due_date" json:"dueDate"`
+	Amount     float64    `db:"amount" json:"amount"`
+	Status     string     `db:"status" json:"status"`
+	PaidAt     *time.Time `db:"paid_at" json:"paidAt,omitempty"`
+	CreatedAt  time.Time  `db:"created_at" json:"createdAt"`
+	UpdatedAt  time.Time  `db:"updated_at" json:"updatedAt"`
+}
+
+// Commission representa a comissao de um promotor por contrato.
+type Commission struct {
+	ID         string     `db:"id" json:"id"`
+	ContractID string     `db:"contract_id" json:"contractID"`
+	PromoterID string     `db:"promoter_id" json:"promoterID"`
+	Amount     float64    `db:"amount" json:"amount"`
+	Approved   bool       `db:"approved" json:"approved"`
+	ApprovedBy string     `db:"approved_by" json:"approvedBy,omitempty"`
+	ApprovedAt *time.Time `db:"approved_at" json:"approvedAt,omitempty"`
+	CreatedAt  time.Time  `db:"created_at" json:"createdAt"`
+	UpdatedAt  time.Time  `db:"updated_at" json:"updatedAt"`
+}

--- a/backend/internal/finance/postgres_repository.go
+++ b/backend/internal/finance/postgres_repository.go
@@ -1,0 +1,100 @@
+package finance
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// PostgresRepository implementa Repository usando PostgreSQL.
+type PostgresRepository struct {
+	db *sqlx.DB
+}
+
+// NewPostgresRepository cria uma instancia de PostgresRepository.
+func NewPostgresRepository(db *sqlx.DB) *PostgresRepository {
+	return &PostgresRepository{db: db}
+}
+
+// ListReceivables retorna as contas a receber opcionamente filtrando por status.
+func (r *PostgresRepository) ListReceivables(ctx context.Context, status string) ([]AccountReceivable, error) {
+	receivables := []AccountReceivable{}
+	q := `SELECT * FROM accounts_receivable WHERE deleted_at IS NULL`
+	if status != "" {
+		q += ` AND status=$1`
+		if err := r.db.SelectContext(ctx, &receivables, q, status); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := r.db.SelectContext(ctx, &receivables, q); err != nil {
+			return nil, err
+		}
+	}
+	return receivables, nil
+}
+
+// MarkAsPaid marca uma conta como paga.
+func (r *PostgresRepository) MarkAsPaid(ctx context.Context, id string) error {
+	const q = `UPDATE accounts_receivable SET status='paid', paid_at=now() WHERE id=$1 AND status='open'`
+	res, err := r.db.ExecContext(ctx, q, id)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 1 {
+		return nil
+	}
+	var status string
+	err = r.db.GetContext(ctx, &status, `SELECT status FROM accounts_receivable WHERE id=$1`, id)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return sql.ErrNoRows
+		}
+		return err
+	}
+	return ErrAlreadyPaid
+}
+
+// ListCommissions retorna as comissoes, opcionalmente apenas pendentes.
+func (r *PostgresRepository) ListCommissions(ctx context.Context, onlyPending bool) ([]Commission, error) {
+	commissions := []Commission{}
+	q := `SELECT * FROM commissions WHERE deleted_at IS NULL`
+	if onlyPending {
+		q += ` AND approved=false`
+	}
+	if err := r.db.SelectContext(ctx, &commissions, q); err != nil {
+		return nil, err
+	}
+	return commissions, nil
+}
+
+// ApproveCommission marca uma comissao como aprovada.
+func (r *PostgresRepository) ApproveCommission(ctx context.Context, id string, approverID string) error {
+	const q = `UPDATE commissions SET approved=true, approved_by=$2, approved_at=now() WHERE id=$1 AND approved=false`
+	res, err := r.db.ExecContext(ctx, q, id, approverID)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 1 {
+		return nil
+	}
+	var approved bool
+	err = r.db.GetContext(ctx, &approved, `SELECT approved FROM commissions WHERE id=$1`, id)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return sql.ErrNoRows
+		}
+		return err
+	}
+	return ErrAlreadyApproved
+}
+
+var _ Repository = (*PostgresRepository)(nil)


### PR DESCRIPTION
## Summary
- implement `finance` package to manage accounts receivable and promoter commissions
- support listing, paying and approving via Postgres repository
- expose `/receivables` and `/commissions` routes guarded with finance RBAC
- integrate finance module into server main
- cover functionality with unit tests

## Testing
- `go vet ./...`
- `go test ./internal/finance -v`


------
https://chatgpt.com/codex/tasks/task_e_6858bee17a0c832bbbdf8e722daad9de