### PR TITLE
Add automated pg_dump backups to MinIO

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ POSTGRES_PASSWORD=rcm_pass
 POSTGRES_DB=rcm_backoffice
 JWT_SECRET=changeme
 GEO_TIMEOUT_MS=5000
+MINIO_BUCKET=rcm-backup

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
 | **DBMigrator** | `migrations/` – `make migrate-*` | Criar e aplicar migrações SQL no PostgreSQL (create, up, down, force). |
 | **Deployer** | `infra/docker-compose.yml` | Fazer `docker-compose pull && up -d` em staging/produção. |
 | **ObservabilityWatcher** | `infra/observability.yml` | Subir stack Prometheus/Grafana e validar dashboards. |
-| **BackupAgent** | `infra/cron/pg_dump.sh` | Executar backup diário do banco e enviar para bucket S3-compatível. |
+| **BackupAgent** | `infra/backup/pg_dump.sh` | Executar backup diário do banco e enviar para bucket S3-compatível. |
 | **CI** | `.github/workflows/ci.yml` | Rodar `go vet ./...` e `go test ./...` e build do frontend em cada push. |
 
 ### Boas práticas para novos agentes

--- a/infra/backup/pg_dump.sh
+++ b/infra/backup/pg_dump.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+FILE="$(date +"%Y-%m-%d_%H%M").sql.gz"
+
+echo "[BackupAgent] starting pg_dump to /backup/$FILE"
+pg_dump -Fc -Z9 -f "/backup/$FILE"
+
+echo "[BackupAgent] upload to bucket $MINIO_BUCKET"
+mc cp "/backup/$FILE" "minio/$MINIO_BUCKET/"
+
+# Remove dumps older than 7 days
+find /backup -name '*.sql.gz' -mtime +7 -delete

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -39,6 +39,25 @@ services:
     environment:
       NODE_ENV: development
 
+  backup:
+    image: minio/mc
+    container_name: rcm-backup
+    entrypoint: ["/bin/sh","-c","echo '0 3 * * * /scripts/pg_dump.sh' > /etc/crontabs/root && crond -f"]
+    volumes:
+      - ./backup/pg_dump.sh:/scripts/pg_dump.sh:ro
+      - ./backup:/backup
+    environment:
+      - PGUSER=${POSTGRES_USER}
+      - PGPASSWORD=${POSTGRES_PASSWORD}
+      - PGHOST=db
+      - PGDATABASE=${POSTGRES_DB}
+      - MINIO_BUCKET=rcm-backup
+      - MC_HOST_minio=http://minioadmin:minioadmin@minio:9000
+    restart: unless-stopped
+    depends_on:
+      - db
+      - minio
+
 volumes:
   db_data:
 


### PR DESCRIPTION
## Summary
- add BackupAgent script for daily pg_dump uploads
- define `backup` service in docker-compose
- document BackupAgent location
- expose `MINIO_BUCKET` env var

## Testing
- `gofmt -w backend`
- *(failed: `docker-compose` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858c08fd308832bb36147f84b25f35f