### PR TITLE
Add Prometheus/Grafana observability stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ docker-compose -f infra/docker-compose.yml up -d --build
 * **Backend**:  [http://localhost:8080/healthz](http://localhost:8080/healthz)
 * **Postgres**: `postgres://rcm:rcm_pass@localhost:5432/rcm_backoffice`
 
+## Observabilidade
+
+```bash
+docker-compose -f infra/observability.yml up -d
+```
+
+Acesse:
+- Prometheus → <http://localhost:9090>
+- Grafana    → <http://localhost:3001>  (admin / admin)
+
 ---
 
 ## Estrutura de pastas

--- a/infra/observability.yml
+++ b/infra/observability.yml
@@ -1,0 +1,41 @@
+version: "3.9"
+
+services:
+  prometheus:
+    image: prom/prometheus:v2.52.0
+    container_name: rcm-prometheus
+    volumes:
+      - ./observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9090:9090"
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:10.4.2
+    container_name: rcm-grafana
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    ports:
+      - "3001:3000"
+    depends_on:
+      - prometheus
+    restart: unless-stopped
+
+  node-exporter:
+    image: prom/node-exporter:v1.8.1
+    container_name: rcm-node-exporter
+    ports:
+      - "9100:9100"
+    restart: unless-stopped
+
+  postgres-exporter:
+    image: quay.io/prometheuscommunity/postgres-exporter:v0.15.0
+    container_name: rcm-postgres-exporter
+    environment:
+      - DATA_SOURCE_NAME=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}?sslmode=disable
+    ports:
+      - "9187:9187"
+    depends_on:
+      - db
+    restart: unless-stopped

--- a/observability/prometheus.yml
+++ b/observability/prometheus.yml
@@ -1,0 +1,15 @@
+global:
+  scrape_interval: 15s
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['prometheus:9090']
+  - job_name: 'node'
+    static_configs:
+      - targets: ['node-exporter:9100']
+  - job_name: 'postgres'
+    static_configs:
+      - targets: ['postgres-exporter:9187']
+  - job_name: 'backend'
+    static_configs:
+      - targets: ['backend:8080']


### PR DESCRIPTION
## Summary
- add `infra/observability.yml` with Prometheus, Grafana and exporters
- provide Prometheus configuration in `observability/prometheus.yml`
- document how to start observability stack in README

## Testing
- `go test ./...`
- `docker-compose -f infra/observability.yml up -d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858c1fde58c832bb9be6cbc2697e4bc