### PR TITLE
Implement Next.js login flow

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,0 +1,9 @@
+import ProtectedRoute from "@/components/ProtectedRoute";
+
+export default function DashboardPage() {
+  return (
+    <ProtectedRoute>
+      <div className="p-4">Dashboard</div>
+    </ProtectedRoute>
+  );
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { AuthProvider } from "@/hooks/useAuth";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <AuthProvider>{children}</AuthProvider>
       </body>
     </html>
   );

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/hooks/useAuth";
+
+export default function LoginPage() {
+  const router = useRouter();
+  const { login } = useAuth();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    try {
+      await login(email, password);
+      router.push("/");
+    } catch {
+      setError("Credenciais inválidas");
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen p-4">
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4 w-64">
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="border p-2"
+        />
+        <input
+          type="password"
+          placeholder="Senha"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="border p-2"
+        />
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        <button type="submit" className="bg-blue-500 text-white p-2">
+          Entrar
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { ReactNode, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { getToken } from "@/hooks/useAuth";
+
+export default function ProtectedRoute({ children }: { children: ReactNode }) {
+  const router = useRouter();
+
+  useEffect(() => {
+    const token = getToken();
+    if (!token) {
+      router.push("/login");
+    }
+  }, [router]);
+
+  return <>{children}</>;
+}

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  ReactNode,
+} from "react";
+
+export const login = async (email: string, password: string) => {
+  const res = await fetch("/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password }),
+  });
+  if (!res.ok) {
+    throw new Error("invalid credentials");
+  }
+  const data = await res.json();
+  localStorage.setItem("token", data.token);
+};
+
+export const logout = () => {
+  localStorage.removeItem("token");
+};
+
+export const getToken = (): string | null => {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem("token");
+};
+
+interface AuthContextType {
+  user: string | null;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType>({
+  user: null,
+  login: async () => {},
+  logout: () => {},
+});
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [user, setUser] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (getToken()) {
+      setUser("authenticated");
+    }
+  }, []);
+
+  const handleLogin = async (email: string, password: string) => {
+    await login(email, password);
+    setUser(email);
+  };
+
+  const handleLogout = () => {
+    logout();
+    setUser(null);
+  };
+
+  return (
+    <AuthContext.Provider
+      value={{ user, login: handleLogin, logout: handleLogout }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);

--- a/frontend/src/util/api.ts
+++ b/frontend/src/util/api.ts
@@ -1,0 +1,14 @@
+import { getToken } from "@/hooks/useAuth";
+
+export async function api<T>(
+  input: RequestInfo,
+  init: RequestInit = {},
+): Promise<T> {
+  const token = getToken();
+  const headers = new Headers(init.headers);
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+  const response = await fetch(input, { ...init, headers });
+  return response.json() as Promise<T>;
+}


### PR DESCRIPTION
## Summary
- add `useAuth` hook with context and helpers
- create `ProtectedRoute` for gating pages
- inject auth token headers with util `api`
- build login page and dashboard example
- wrap app with `AuthProvider`

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6858c28a65d8832bb37f42e8bf1164cd