### PR TITLE
Add Docker build workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,41 @@
+name: Build & Push Images
+on:
+  push:
+    branches: [ main ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_BACKEND: ${{ github.repository }}-backend
+  IMAGE_FRONTEND: ${{ github.repository }}-frontend
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build backend image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_BACKEND }}:${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_BACKEND }}:latest
+      - name: Build frontend image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_FRONTEND }}:${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_FRONTEND }}:latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 | **ObservabilityWatcher** | `infra/observability.yml` | Subir stack Prometheus/Grafana e validar dashboards. |
 | **BackupAgent** | `infra/backup/pg_dump.sh` | Executar backup diário do banco e enviar para bucket S3-compatível. |
 | **CI** | `.github/workflows/ci.yml` | Rodar `go vet ./...` e `go test ./...` e build do frontend em cada push. |
+| **ImagePublisher** | `.github/workflows/docker-build.yml` | Build e push das imagens backend/frontend para o GHCR a cada merge na `main`. |
 
 ### Boas práticas para novos agentes
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,19 @@ docs/      # documentação complementar
 1. Rode `gofmt -w .` dentro do diretório `backend/` antes de commitar qualquer mudança em Go.
 2. Execute `npm run lint` no `frontend/` para garantir a qualidade do código JavaScript e TypeScript.
 
+## Imagens no GHCR
+
+Cada merge na branch `main` gera imagens `:latest` e `:<commit_sha>` publicadas em **ghcr.io**.
+
+Para atualizar em produção:
+
+```bash
+docker-compose pull backend frontend
+docker-compose up -d
+```
+
+Opcional: crie o secret `GHCR_PAT` se preferir token permanente.
+
 ---
 
 ## Licença


### PR DESCRIPTION
## Summary
- build and push backend/frontend images to ghcr.io on merges to main
- document GHCR images and how to pull in production
- register new `ImagePublisher` agent

## Testing
- `make test`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858c58cea88832b8fbd66d35c624fe9