### PR TITLE
Implement lead module with kanban frontend

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/smithl4b/rcm.backoffice/internal/contract"
 	"github.com/smithl4b/rcm.backoffice/internal/customer"
 	"github.com/smithl4b/rcm.backoffice/internal/finance"
+	"github.com/smithl4b/rcm.backoffice/internal/lead"
 	"github.com/smithl4b/rcm.backoffice/internal/promoter"
 	"github.com/smithl4b/rcm.backoffice/internal/service"
 )
@@ -43,6 +44,7 @@ func main() {
 	customerRepo := customer.NewPostgresRepository(db)
 	serviceRepo := service.NewPostgresRepository(db)
 	promoterRepo := promoter.NewPostgresRepository(db)
+	leadRepo := lead.NewPostgresRepository(db)
 	contractRepo := contract.NewPostgresRepository(db)
 	financeRepo := finance.NewPostgresRepository(db)
 	authRepo := auth.NewPostgresRepository(db)
@@ -76,6 +78,7 @@ func main() {
 
 		service.RegisterRoutes(pr, serviceRepo)
 		promoter.RegisterRoutes(pr, promoterRepo)
+		lead.RegisterRoutes(pr, leadRepo)
 		contract.RegisterRoutes(pr, contractRepo)
 		finance.RegisterRoutes(pr, financeRepo)
 	})

--- a/backend/internal/lead/handler.go
+++ b/backend/internal/lead/handler.go
@@ -1,0 +1,201 @@
+package lead
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-playground/validator/v10"
+	"github.com/oklog/ulid/v2"
+
+	"github.com/smithl4b/rcm.backoffice/internal/auth"
+)
+
+// RegisterRoutes adiciona as rotas do modulo Lead.
+func RegisterRoutes(r chi.Router, repo Repository) {
+	h := handler{repo: repo, validate: validator.New()}
+
+	r.Group(func(gr chi.Router) {
+		gr.Use(auth.RequireRole("admin", "promoter"))
+		gr.Get("/leads", h.list)
+	})
+
+	r.Post("/leads", h.create)
+	r.With(auth.RequireRole("finance", "admin")).Put("/leads/{id}/status", h.updateStatus)
+	r.Put("/leads/{id}", h.update)
+	r.Delete("/leads/{id}", h.remove)
+}
+
+type handler struct {
+	repo     Repository
+	validate *validator.Validate
+}
+
+type createLeadInput struct {
+	CustomerID string  `json:"customer_id" validate:"required"`
+	ServiceID  string  `json:"service_id" validate:"required"`
+	PromoterID *string `json:"promoter_id"`
+	Notes      string  `json:"notes"`
+}
+
+type updateLeadInput struct {
+	ServiceID  string  `json:"service_id" validate:"required"`
+	PromoterID *string `json:"promoter_id"`
+	Notes      string  `json:"notes"`
+}
+
+type statusInput struct {
+	Status string `json:"status" validate:"required,oneof=qualified proposal contract"`
+}
+
+// @Summary      Lista leads
+// @Tags         leads
+// @Security     BearerAuth
+// @Success      200  {array}  Lead
+// @Router       /leads [get]
+func (h handler) list(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	status := r.URL.Query().Get("status")
+	leads, err := h.repo.List(r.Context(), status)
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	_ = json.NewEncoder(w).Encode(leads)
+}
+
+// @Summary      Cria lead
+// @Tags         leads
+// @Security     BearerAuth
+// @Success      201  {object}  Lead
+// @Router       /leads [post]
+func (h handler) create(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	var in createLeadInput
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		return
+	}
+	if err := h.validate.Struct(in); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+
+	l := Lead{
+		ID:         ulid.Make().String(),
+		CustomerID: in.CustomerID,
+		ServiceID:  in.ServiceID,
+		PromoterID: in.PromoterID,
+		Status:     "lead",
+		Notes:      in.Notes,
+		CreatedAt:  time.Now(),
+		UpdatedAt:  time.Now(),
+	}
+
+	if err := h.repo.Create(r.Context(), &l); err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Location", "/leads/"+l.ID)
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(l)
+}
+
+// @Summary      Atualiza status do lead
+// @Tags         leads
+// @Security     BearerAuth
+// @Success      204  {null}  nil
+// @Router       /leads/{id}/status [put]
+func (h handler) updateStatus(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	var in statusInput
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		return
+	}
+	if err := h.validate.Struct(in); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+
+	if err := h.repo.UpdateStatus(r.Context(), id, in.Status); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+		if err.Error() == "invalid status transition" {
+			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+			return
+		}
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// @Summary      Atualiza lead
+// @Tags         leads
+// @Security     BearerAuth
+// @Success      204  {null}  nil
+// @Router       /leads/{id} [put]
+func (h handler) update(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	id := chi.URLParam(r, "id")
+
+	var in updateLeadInput
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		return
+	}
+	if err := h.validate.Struct(in); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+
+	l := Lead{
+		ID:         id,
+		ServiceID:  in.ServiceID,
+		PromoterID: in.PromoterID,
+		Notes:      in.Notes,
+		UpdatedAt:  time.Now(),
+	}
+
+	if err := h.repo.Update(r.Context(), &l); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// @Summary      Remove lead
+// @Tags         leads
+// @Security     BearerAuth
+// @Success      204  {null}  nil
+// @Router       /leads/{id} [delete]
+func (h handler) remove(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := h.repo.SoftDelete(r.Context(), id); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/backend/internal/lead/handler_test.go
+++ b/backend/internal/lead/handler_test.go
@@ -1,0 +1,139 @@
+package lead
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/smithl4b/rcm.backoffice/internal/auth"
+)
+
+type fakeRepository struct {
+	leads []Lead
+}
+
+func (f *fakeRepository) List(ctx context.Context, status string) ([]Lead, error) {
+	out := make([]Lead, 0)
+	for _, l := range f.leads {
+		if l.DeletedAt == nil && (status == "" || l.Status == status) {
+			out = append(out, l)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeRepository) Create(ctx context.Context, l *Lead) error {
+	f.leads = append(f.leads, *l)
+	return nil
+}
+
+func (f *fakeRepository) UpdateStatus(ctx context.Context, id string, newStatus string) error {
+	for i, l := range f.leads {
+		if l.ID == id {
+			if allowedTransitions[l.Status] != newStatus {
+				return errors.New("invalid status transition")
+			}
+			l.Status = newStatus
+			f.leads[i] = l
+			return nil
+		}
+	}
+	return sql.ErrNoRows
+}
+
+func (f *fakeRepository) Update(ctx context.Context, l *Lead) error {
+	for i, lead := range f.leads {
+		if lead.ID == l.ID {
+			lead.ServiceID = l.ServiceID
+			lead.PromoterID = l.PromoterID
+			lead.Notes = l.Notes
+			f.leads[i] = lead
+			return nil
+		}
+	}
+	return sql.ErrNoRows
+}
+
+func (f *fakeRepository) SoftDelete(ctx context.Context, id string) error {
+	for i, l := range f.leads {
+		if l.ID == id {
+			if l.DeletedAt != nil {
+				return sql.ErrNoRows
+			}
+			now := time.Now()
+			l.DeletedAt = &now
+			f.leads[i] = l
+			return nil
+		}
+	}
+	return sql.ErrNoRows
+}
+
+func setupRouter(repo Repository, role string) (*chi.Mux, string) {
+	os.Setenv("JWT_SECRET", "testsecret")
+	claims := jwt.MapClaims{"sub": "u1", "role": role, "exp": time.Now().Add(time.Hour).Unix()}
+	tokenStr, _ := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte("testsecret"))
+
+	r := chi.NewRouter()
+	r.Use(auth.AuthMiddleware)
+	RegisterRoutes(r, repo)
+	return r, tokenStr
+}
+
+func TestCreateLead(t *testing.T) {
+	repo := &fakeRepository{}
+	router := chi.NewRouter()
+	RegisterRoutes(router, repo)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	body := strings.NewReader(`{"customer_id":"c1","service_id":"s1"}`)
+	resp, err := http.Post(server.URL+"/leads", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST /leads error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d", resp.StatusCode)
+	}
+
+	var l Lead
+	if err := json.NewDecoder(resp.Body).Decode(&l); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if l.CustomerID != "c1" || l.ServiceID != "s1" || l.Status != "lead" {
+		t.Fatalf("unexpected lead data: %+v", l)
+	}
+}
+
+func TestStatusTransitionInvalid(t *testing.T) {
+	repo := &fakeRepository{leads: []Lead{{ID: "l1", Status: "lead"}}}
+	r, token := setupRouter(repo, "finance")
+	server := httptest.NewServer(r)
+	defer server.Close()
+
+	body := strings.NewReader(`{"status":"contract"}`)
+	req, _ := http.NewRequest(http.MethodPut, server.URL+"/leads/l1/status", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT /leads/{id}/status error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+}

--- a/backend/internal/lead/lead.go
+++ b/backend/internal/lead/lead.go
@@ -1,0 +1,12 @@
+package lead
+
+import "context"
+
+// Repository define operacoes para gerenciar leads de vendas.
+type Repository interface {
+	List(ctx context.Context, statusFilter string) ([]Lead, error)
+	Create(ctx context.Context, l *Lead) error
+	UpdateStatus(ctx context.Context, id string, newStatus string) error
+	Update(ctx context.Context, l *Lead) error
+	SoftDelete(ctx context.Context, id string) error
+}

--- a/backend/internal/lead/model.go
+++ b/backend/internal/lead/model.go
@@ -1,0 +1,16 @@
+package lead
+
+import "time"
+
+// Lead representa uma oportunidade comercial no pipeline de vendas.
+type Lead struct {
+	ID         string     `db:"id" json:"id"`
+	CustomerID string     `db:"customer_id" json:"customerID"`
+	PromoterID *string    `db:"promoter_id" json:"promoterID,omitempty"`
+	ServiceID  string     `db:"service_id" json:"serviceID"`
+	Status     string     `db:"status" json:"status"`
+	Notes      string     `db:"notes" json:"notes"`
+	CreatedAt  time.Time  `db:"created_at" json:"createdAt"`
+	UpdatedAt  time.Time  `db:"updated_at" json:"updatedAt"`
+	DeletedAt  *time.Time `db:"deleted_at" json:"deletedAt,omitempty"`
+}

--- a/backend/internal/lead/postgres_repository.go
+++ b/backend/internal/lead/postgres_repository.go
@@ -1,0 +1,101 @@
+package lead
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/oklog/ulid/v2"
+)
+
+// PostgresRepository implementa Repository usando PostgreSQL.
+type PostgresRepository struct {
+	db *sqlx.DB
+}
+
+// NewPostgresRepository cria uma instancia de PostgresRepository.
+func NewPostgresRepository(db *sqlx.DB) *PostgresRepository {
+	return &PostgresRepository{db: db}
+}
+
+// List retorna todos os leads filtrando opcionalmente por status.
+func (r *PostgresRepository) List(ctx context.Context, status string) ([]Lead, error) {
+	leads := []Lead{}
+	q := `SELECT * FROM leads WHERE deleted_at IS NULL`
+	if status != "" {
+		q += ` AND status = $1`
+		if err := r.db.SelectContext(ctx, &leads, q, status); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := r.db.SelectContext(ctx, &leads, q); err != nil {
+			return nil, err
+		}
+	}
+	return leads, nil
+}
+
+// Create insere um novo lead gerando ULID.
+func (r *PostgresRepository) Create(ctx context.Context, l *Lead) error {
+	l.ID = ulid.Make().String()
+	const q = `INSERT INTO leads (id, customer_id, promoter_id, service_id, status, notes)
+        VALUES (:id, :customer_id, :promoter_id, :service_id, :status, :notes)`
+	_, err := r.db.NamedExecContext(ctx, q, l)
+	return err
+}
+
+var allowedTransitions = map[string]string{
+	"lead":      "qualified",
+	"qualified": "proposal",
+	"proposal":  "contract",
+}
+
+// UpdateStatus atualiza o status de um lead verificando transicao valida.
+func (r *PostgresRepository) UpdateStatus(ctx context.Context, id string, newStatus string) error {
+	var current string
+	if err := r.db.GetContext(ctx, &current, `SELECT status FROM leads WHERE id=$1 AND deleted_at IS NULL`, id); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return sql.ErrNoRows
+		}
+		return err
+	}
+	if allowedTransitions[current] != newStatus {
+		return errors.New("invalid status transition")
+	}
+	const q = `UPDATE leads SET status=$2, updated_at=now() WHERE id=$1 AND deleted_at IS NULL`
+	res, err := r.db.ExecContext(ctx, q, id, newStatus)
+	if err != nil {
+		return err
+	}
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+// Update altera dados de um lead.
+func (r *PostgresRepository) Update(ctx context.Context, l *Lead) error {
+	const q = `UPDATE leads SET promoter_id=:promoter_id, service_id=:service_id, notes=:notes, updated_at=now()
+        WHERE id=:id AND deleted_at IS NULL`
+	res, err := r.db.NamedExecContext(ctx, q, l)
+	if err != nil {
+		return err
+	}
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+// SoftDelete marca um lead como removido.
+func (r *PostgresRepository) SoftDelete(ctx context.Context, id string) error {
+	res, err := r.db.ExecContext(ctx, `UPDATE leads SET deleted_at=now() WHERE id=$1 AND deleted_at IS NULL`, id)
+	if err != nil {
+		return err
+	}
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,11 +8,14 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
         "@headlessui/react": "^2.2.4",
         "framer-motion": "^12.18.1",
         "next": "15.3.4",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "swr": "^2.3.3"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -51,6 +54,59 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2737,6 +2793,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -5984,6 +6049,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.3.tgz",
+      "integrity": "sha512-dshNvs3ExOqtZ6kJBaAsabhPdHyeY4P2cKwRCniDVifBMoG/SVI7tfLWqPXriVspf2Rg4tPzXJTnwaihIeFw2A==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/tabbable": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,11 +9,14 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "@headlessui/react": "^2.2.4",
     "framer-motion": "^12.18.1",
     "next": "15.3.4",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "swr": "^2.3.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/frontend/src/app/leads/LeadCard.tsx
+++ b/frontend/src/app/leads/LeadCard.tsx
@@ -1,0 +1,25 @@
+"use client";
+import { CSS } from "@dnd-kit/utilities";
+import { useSortable } from "@dnd-kit/sortable";
+
+interface LeadCardProps {
+  id: string;
+  customer: { trade_name: string };
+  service: { name: string };
+  createdAt: string;
+}
+
+export default function LeadCard({ id, customer, service, createdAt }: LeadCardProps) {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+  return (
+    <div ref={setNodeRef} style={style} {...attributes} {...listeners} className="border p-2 bg-white mb-2">
+      <div className="font-semibold">{customer.trade_name}</div>
+      <div className="text-sm">{service.name}</div>
+      <div className="text-xs text-gray-500">{new Date(createdAt).toLocaleDateString()}</div>
+    </div>
+  );
+}

--- a/frontend/src/app/leads/NewLeadModal.tsx
+++ b/frontend/src/app/leads/NewLeadModal.tsx
@@ -1,0 +1,78 @@
+"use client";
+import { Dialog, Transition } from "@headlessui/react";
+import { Fragment, FormEvent, useState, useEffect } from "react";
+import { api } from "@/util/api";
+import { getToken } from "@/hooks/useAuth";
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+interface Customer { id: string; trade_name: string; }
+interface Service { id: string; name: string; }
+
+export default function NewLeadModal({ isOpen, onClose, onSuccess }: ModalProps) {
+  const [customers, setCustomers] = useState<Customer[]>([]);
+  const [services, setServices] = useState<Service[]>([]);
+  const [customerID, setCustomerID] = useState("{}");
+  const [serviceID, setServiceID] = useState("{}");
+  const [notes, setNotes] = useState("");
+
+  useEffect(() => {
+    (async () => {
+      setCustomers(await api<Customer[]>("/customers"));
+      setServices(await api<Service[]>("/services"));
+    })();
+  }, []);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    const payload: any = { customer_id: customerID, service_id: serviceID, notes };
+    const token = getToken();
+    if (token) {
+      const payloadJwt = JSON.parse(atob(token.split(".")[1]));
+      if (payloadJwt.role === "promoter") payload.promoter_id = payloadJwt.sub;
+    }
+    await api("/leads", { method: "POST", body: JSON.stringify(payload) });
+    onSuccess();
+    onClose();
+  };
+
+  return (
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog as="div" className="fixed inset-0 z-10 overflow-y-auto" onClose={onClose}>
+        <div className="min-h-screen px-4 text-center">
+          <Transition.Child as={Fragment} enter="ease-out duration-300" enterFrom="opacity-0" enterTo="opacity-100" leave="ease-in duration-200" leaveFrom="opacity-100" leaveTo="opacity-0">
+            <div className="fixed inset-0 bg-black/50" />
+          </Transition.Child>
+          <span className="inline-block h-screen align-middle" aria-hidden="true">&#8203;</span>
+          <Transition.Child as={Fragment} enter="ease-out duration-300" enterFrom="opacity-0 scale-95" enterTo="opacity-100 scale-100" leave="ease-in duration-200" leaveFrom="opacity-100 scale-100" leaveTo="opacity-0 scale-95">
+            <div className="inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-xl">
+              <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+                <select className="border p-2" value={customerID} onChange={(e) => setCustomerID(e.target.value)} required>
+                  <option value="" disabled>Cliente...</option>
+                  {customers.map((c) => (
+                    <option key={c.id} value={c.id}>{c.trade_name}</option>
+                  ))}
+                </select>
+                <select className="border p-2" value={serviceID} onChange={(e) => setServiceID(e.target.value)} required>
+                  <option value="" disabled>Serviço...</option>
+                  {services.map((s) => (
+                    <option key={s.id} value={s.id}>{s.name}</option>
+                  ))}
+                </select>
+                <textarea className="border p-2" placeholder="Notas" value={notes} onChange={(e) => setNotes(e.target.value)} />
+                <div className="flex gap-2 mt-2">
+                  <button type="button" onClick={onClose} className="border px-4 py-2">Cancelar</button>
+                  <button type="submit" className="bg-blue-500 text-white px-4 py-2">Salvar</button>
+                </div>
+              </form>
+            </div>
+          </Transition.Child>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+}

--- a/frontend/src/app/leads/page.tsx
+++ b/frontend/src/app/leads/page.tsx
@@ -1,0 +1,90 @@
+"use client";
+import { useState } from "react";
+import useSWR from "swr";
+import { DndContext, closestCenter } from "@dnd-kit/core";
+import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import ProtectedRoute from "@/components/ProtectedRoute";
+import LeadCard from "./LeadCard";
+import NewLeadModal from "./NewLeadModal";
+import { api } from "@/util/api";
+
+interface Lead {
+  id: string;
+  customer: { trade_name: string };
+  service: { name: string };
+  createdAt: string;
+}
+
+const fetcher = (url: string) => api(url);
+
+export default function LeadsPage() {
+  const { data: leadsLead, mutate: mutLead } = useSWR<Lead[]>("/leads?status=lead", fetcher);
+  const { data: leadsQualified, mutate: mutQualified } = useSWR<Lead[]>("/leads?status=qualified", fetcher);
+  const { data: leadsProposal, mutate: mutProposal } = useSWR<Lead[]>("/leads?status=proposal", fetcher);
+  const { data: leadsContract, mutate: mutContract } = useSWR<Lead[]>("/leads?status=contract", fetcher);
+
+  const [open, setOpen] = useState(false);
+
+  const refresh = () => {
+    mutLead();
+    mutQualified();
+    mutProposal();
+    mutContract();
+  };
+
+  const onDragEnd = async (event: any) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const targetStatus = over.id as string;
+    await api(`/leads/${active.id}/status`, { method: "PUT", body: JSON.stringify({ status: targetStatus }) });
+    refresh();
+  };
+
+  return (
+    <ProtectedRoute roles={["admin", "promoter"]}>
+      <div className="p-4">
+        <div className="flex justify-between mb-4">
+          <h1 className="text-xl font-bold">Leads</h1>
+          <button onClick={() => setOpen(true)} className="bg-blue-500 text-white px-4 py-2">Novo Lead</button>
+        </div>
+        <DndContext onDragEnd={onDragEnd} collisionDetection={closestCenter}>
+          <div className="grid grid-cols-4 gap-4">
+            <SortableContext items={leadsLead?.map((l) => l.id) || []} strategy={verticalListSortingStrategy} id="lead">
+              <div id="lead" className="bg-gray-100 p-2 min-h-[200px]">
+                <h2 className="font-semibold mb-2">Lead</h2>
+                {leadsLead?.map((l) => (
+                  <LeadCard key={l.id} id={l.id} customer={l.customer} service={l.service} createdAt={l.createdAt} />
+                ))}
+              </div>
+            </SortableContext>
+            <SortableContext items={leadsQualified?.map((l) => l.id) || []} strategy={verticalListSortingStrategy} id="qualified">
+              <div id="qualified" className="bg-gray-100 p-2 min-h-[200px]">
+                <h2 className="font-semibold mb-2">Qualified</h2>
+                {leadsQualified?.map((l) => (
+                  <LeadCard key={l.id} id={l.id} customer={l.customer} service={l.service} createdAt={l.createdAt} />
+                ))}
+              </div>
+            </SortableContext>
+            <SortableContext items={leadsProposal?.map((l) => l.id) || []} strategy={verticalListSortingStrategy} id="proposal">
+              <div id="proposal" className="bg-gray-100 p-2 min-h-[200px]">
+                <h2 className="font-semibold mb-2">Proposal</h2>
+                {leadsProposal?.map((l) => (
+                  <LeadCard key={l.id} id={l.id} customer={l.customer} service={l.service} createdAt={l.createdAt} />
+                ))}
+              </div>
+            </SortableContext>
+            <SortableContext items={leadsContract?.map((l) => l.id) || []} strategy={verticalListSortingStrategy} id="contract">
+              <div id="contract" className="bg-gray-100 p-2 min-h-[200px]">
+                <h2 className="font-semibold mb-2">Contract</h2>
+                {leadsContract?.map((l) => (
+                  <LeadCard key={l.id} id={l.id} customer={l.customer} service={l.service} createdAt={l.createdAt} />
+                ))}
+              </div>
+            </SortableContext>
+          </div>
+        </DndContext>
+        <NewLeadModal isOpen={open} onClose={() => setOpen(false)} onSuccess={refresh} />
+      </div>
+    </ProtectedRoute>
+  );
+}


### PR DESCRIPTION
## Summary
- add Lead domain with repository, handler and tests
- register Lead routes in backend server
- install dnd-kit, sortable and swr for frontend
- create Kanban board page with draggable Lead cards
- add LeadCard and NewLeadModal components

## Testing
- `go vet ./...`
- `go test ./...`
- `npm run build` *(fails: Failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_685a017aa70c832b8a2bcb53f4e201ed