### PR TITLE
Implement services management page

### DIFF
--- a/frontend/src/app/services/ServiceForm.tsx
+++ b/frontend/src/app/services/ServiceForm.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+import { api } from "@/util/api";
+
+interface Service {
+  id: string;
+  name: string;
+  description?: string;
+  basePrice: number;
+  isActive: boolean;
+}
+
+interface ServiceFormProps {
+  service?: Service;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export default function ServiceForm({ service, onClose, onSuccess }: ServiceFormProps) {
+  const [name, setName] = useState(service?.name || "");
+  const [description, setDescription] = useState(service?.description || "");
+  const [price, setPrice] = useState(service?.basePrice ?? 0);
+  const [active, setActive] = useState(service?.isActive ?? true);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const validate = () => {
+    if (!name) return "Nome é obrigatório";
+    if (price < 0) return "Preço deve ser maior ou igual a 0";
+    return "";
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    const err = validate();
+    if (err) {
+      setError(err);
+      return;
+    }
+    setError("");
+    setLoading(true);
+    const payload = {
+      name,
+      description,
+      base_price: price,
+      is_active: active,
+    };
+    try {
+      if (service) {
+        await api(`/services/${service.id}`, {
+          method: "PUT",
+          body: JSON.stringify(payload),
+        });
+      } else {
+        await api("/services", {
+          method: "POST",
+          body: JSON.stringify(payload),
+        });
+      }
+      onSuccess();
+    } catch {
+      setError("Erro ao salvar serviço");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+      <input
+        className="border p-2"
+        placeholder="Nome"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        required
+      />
+      <textarea
+        className="border p-2"
+        placeholder="Descrição"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+      />
+      <input
+        type="number"
+        min="0"
+        step="0.01"
+        className="border p-2"
+        placeholder="Preço"
+        value={price}
+        onChange={(e) => setPrice(parseFloat(e.target.value))}
+        required
+      />
+      <label className="flex items-center gap-2">
+        <input type="checkbox" checked={active} onChange={(e) => setActive(e.target.checked)} />
+        Ativo
+      </label>
+      {error && <p className="text-red-500 text-sm">{error}</p>}
+      <div className="flex gap-2 mt-2">
+        <button type="button" onClick={onClose} className="border px-4 py-2">
+          Cancelar
+        </button>
+        <button type="submit" className="bg-blue-500 text-white px-4 py-2" disabled={loading}>
+          {loading ? (
+            <div className="h-4 w-4 border-2 border-gray-300 border-t-transparent rounded-full animate-spin" />
+          ) : (
+            "Salvar"
+          )}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/app/services/page.tsx
+++ b/frontend/src/app/services/page.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useState } from "react";
+import { Dialog, Transition } from "@headlessui/react";
+import useSWR from "swr";
+import ProtectedRoute from "@/components/ProtectedRoute";
+import Money from "@/components/Money";
+import Toast from "@/components/Toast";
+import { api } from "@/util/api";
+import ServiceForm from "./ServiceForm";
+
+interface Service {
+  id: string;
+  name: string;
+  description?: string;
+  basePrice: number;
+  isActive: boolean;
+}
+
+const fetcher = (url: string) => api<Service[]>(url);
+
+export default function ServicesPage() {
+  const { data, isLoading, mutate } = useSWR("/services", fetcher);
+  const [isOpen, setIsOpen] = useState(false);
+  const [editing, setEditing] = useState<Service | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+
+  const closeModal = () => {
+    setIsOpen(false);
+    setEditing(null);
+  };
+  const openForNew = () => {
+    setEditing(null);
+    setIsOpen(true);
+  };
+  const openForEdit = (s: Service) => {
+    setEditing(s);
+    setIsOpen(true);
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm("Remover serviço?")) return;
+    try {
+      await api(`/services/${id}`, { method: "DELETE" });
+      setToast("Serviço removido");
+      mutate();
+    } catch {
+      setToast("Erro ao remover serviço");
+    } finally {
+      setTimeout(() => setToast(null), 3000);
+    }
+  };
+
+  const handleSuccess = () => {
+    mutate();
+    setToast("Serviço salvo");
+    setTimeout(() => setToast(null), 3000);
+    closeModal();
+  };
+
+  return (
+    <ProtectedRoute roles={["admin"]}>
+      <div className="p-4">
+        <div className="flex justify-between items-center mb-4">
+          <h1 className="text-xl font-bold">Serviços</h1>
+          <button onClick={openForNew} className="bg-blue-500 text-white px-4 py-2">
+            Novo Serviço
+          </button>
+        </div>
+        {isLoading ? (
+          <div className="flex justify-center p-4">
+            <div className="h-5 w-5 border-2 border-gray-300 border-t-transparent rounded-full animate-spin" />
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50 sticky top-0">
+                <tr>
+                  <th className="px-4 py-2 text-left">Nome</th>
+                  <th className="px-4 py-2 text-left">Descrição</th>
+                  <th className="px-4 py-2 text-left">Preço</th>
+                  <th className="px-4 py-2 text-left">Ativo</th>
+                  <th className="px-4 py-2 text-left">Ações</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data?.map((s, idx) => (
+                  <tr key={s.id} className={idx % 2 ? "bg-gray-50" : "bg-white"}>
+                    <td className="px-4 py-2">{s.name}</td>
+                    <td className="px-4 py-2">{s.description}</td>
+                    <td className="px-4 py-2">
+                      <Money value={s.basePrice} />
+                    </td>
+                    <td className="px-4 py-2">{s.isActive ? "Sim" : "Não"}</td>
+                    <td className="px-4 py-2 space-x-2">
+                      <button onClick={() => openForEdit(s)}>✏️</button>
+                      <button onClick={() => handleDelete(s.id)}>🗑</button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        <Transition appear show={isOpen} as="div">
+          <Dialog as="div" className="fixed inset-0 z-10 overflow-y-auto" onClose={closeModal}>
+            <div className="min-h-screen px-4 text-center">
+              <Transition.Child
+                as="div"
+                className="fixed inset-0 bg-black/50"
+                enter="ease-out duration-300"
+                enterFrom="opacity-0"
+                enterTo="opacity-100"
+                leave="ease-in duration-200"
+                leaveFrom="opacity-100"
+                leaveTo="opacity-0"
+              />
+              <span className="inline-block h-screen align-middle" aria-hidden="true">
+                &#8203;
+              </span>
+              <Transition.Child
+                as="div"
+                enter="ease-out duration-300"
+                enterFrom="opacity-0 scale-95"
+                enterTo="opacity-100 scale-100"
+                leave="ease-in duration-200"
+                leaveFrom="opacity-100 scale-100"
+                leaveTo="opacity-0 scale-95"
+                className="inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-xl"
+              >
+                <ServiceForm service={editing || undefined} onClose={closeModal} onSuccess={handleSuccess} />
+              </Transition.Child>
+            </div>
+          </Dialog>
+        </Transition>
+        <Toast message={toast} />
+      </div>
+    </ProtectedRoute>
+  );
+}


### PR DESCRIPTION
## Summary
- add `ServiceForm` component
- create `/services` page with CRUD features

## Testing
- `npm install` *(first run)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685a1551dca8832bb5c1468bb7f86ee7