### PR TITLE
Implement contracts page with attachments

### DIFF
--- a/frontend/src/app/contracts/Attachments.tsx
+++ b/frontend/src/app/contracts/Attachments.tsx
@@ -1,0 +1,101 @@
+"use client";
+import { useRef, useState } from "react";
+import useSWR from "swr";
+import Toast from "@/components/Toast";
+import { api, apiPresign } from "@/util/api";
+
+interface Attachment {
+  id: string;
+  filename: string;
+  url: string;
+}
+
+const fetcher = (url: string) => api<Attachment[]>(url);
+
+export default function Attachments({ contractId }: { contractId: string }) {
+  const { data, isLoading, mutate } = useSWR(
+    `/contracts/${contractId}/attachments`,
+    fetcher,
+  );
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [toast, setToast] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+
+  const selectFile = () => inputRef.current?.click();
+
+  const onFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    e.target.value = "";
+    try {
+      setUploading(true);
+      const url = await apiPresign(
+        `/contracts/${contractId}/attachments/presign`,
+        file.name,
+      );
+      await fetch(url, { method: "PUT", body: file });
+      await api(`/contracts/${contractId}/attachments`, {
+        method: "POST",
+        body: JSON.stringify({ filename: file.name, url }),
+      });
+      setToast("Arquivo enviado");
+      mutate();
+    } catch {
+      setToast("Erro ao enviar arquivo");
+    } finally {
+      setUploading(false);
+      setTimeout(() => setToast(null), 3000);
+    }
+  };
+
+  const remove = async (id: string) => {
+    if (!confirm("Remover arquivo?")) return;
+    try {
+      await api(`/contracts/${contractId}/attachments/${id}`, { method: "DELETE" });
+      setToast("Arquivo removido");
+      mutate();
+    } catch {
+      setToast("Erro ao remover arquivo");
+    } finally {
+      setTimeout(() => setToast(null), 3000);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      {isLoading ? (
+        <div className="h-5 w-5 border-2 border-gray-300 border-t-transparent rounded-full animate-spin" />
+      ) : (
+        <ul className="space-y-1">
+          {data?.map((a) => (
+            <li key={a.id} className="flex justify-between items-center">
+              <a href={a.url} target="_blank" rel="noopener noreferrer" className="text-blue-600 underline">
+                {a.filename}
+              </a>
+              <button onClick={() => remove(a.id)}>🗑</button>
+            </li>
+          ))}
+        </ul>
+      )}
+      <input
+        type="file"
+        ref={inputRef}
+        onChange={onFileChange}
+        className="hidden"
+      />
+      <button
+        type="button"
+        onClick={selectFile}
+        className="border px-2 py-1"
+        disabled={uploading}
+      >
+        {uploading ? (
+          <div className="h-4 w-4 border-2 border-gray-300 border-t-transparent rounded-full animate-spin" />
+        ) : (
+          "Adicionar Arquivo"
+        )}
+      </button>
+      <Toast message={toast} />
+    </div>
+  );
+}

--- a/frontend/src/app/contracts/ContractForm.tsx
+++ b/frontend/src/app/contracts/ContractForm.tsx
@@ -1,0 +1,199 @@
+"use client";
+import { FormEvent, useEffect, useState } from "react";
+import Attachments from "./Attachments";
+import { api } from "@/util/api";
+
+interface ContractFormProps {
+  contract?: Contract;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export interface Contract {
+  id: string;
+  customer?: { id: string; trade_name: string };
+  service?: { id: string; name: string };
+  promoter?: { id: string; name: string };
+  value_total: number;
+  start_date: string;
+  end_date?: string;
+  status: string;
+}
+
+interface Customer { id: string; trade_name: string; }
+interface Service { id: string; name: string; }
+interface Promoter { id: string; name: string; }
+
+export default function ContractForm({ contract, onClose, onSuccess }: ContractFormProps) {
+  const [customers, setCustomers] = useState<Customer[]>([]);
+  const [services, setServices] = useState<Service[]>([]);
+  const [promoters, setPromoters] = useState<Promoter[]>([]);
+
+  const [customerInput, setCustomerInput] = useState(contract?.customer?.trade_name || "");
+  const [customerID, setCustomerID] = useState(contract?.customer?.id || "");
+  const [serviceID, setServiceID] = useState(contract?.service?.id || "");
+  const [promoterID, setPromoterID] = useState(contract?.promoter?.id || "");
+  const [valueTotal, setValueTotal] = useState(contract?.value_total ?? 0);
+  const [startDate, setStartDate] = useState(contract?.start_date || "");
+  const [endDate, setEndDate] = useState(contract?.end_date || "");
+  const [status, setStatus] = useState(contract?.status || "active");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    (async () => {
+      setCustomers(await api<Customer[]>("/customers"));
+      setServices(await api<Service[]>("/services?active=true"));
+      setPromoters(await api<Promoter[]>("/promoters"));
+    })();
+  }, []);
+
+  useEffect(() => {
+    const found = customers.find((c) => c.trade_name === customerInput);
+    if (found) setCustomerID(found.id);
+  }, [customerInput, customers]);
+
+  const validate = () => {
+    if (!customerID) return "Cliente obrigatório";
+    if (!serviceID) return "Serviço obrigatório";
+    if (valueTotal < 0) return "Valor inválido";
+    if (startDate && endDate && new Date(startDate) > new Date(endDate))
+      return "Datas incoerentes";
+    return "";
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    const err = validate();
+    if (err) {
+      setError(err);
+      return;
+    }
+    setLoading(true);
+    setError("");
+    const payload = {
+      customer_id: customerID,
+      service_id: serviceID,
+      promoter_id: promoterID || undefined,
+      value_total: valueTotal,
+      start_date: startDate,
+      end_date: endDate,
+      status,
+    };
+    try {
+      if (contract) {
+        await api(`/contracts/${contract.id}`, {
+          method: "PUT",
+          body: JSON.stringify(payload),
+        });
+      } else {
+        await api("/contracts", { method: "POST", body: JSON.stringify(payload) });
+      }
+      onSuccess();
+    } catch {
+      setError("Erro ao salvar");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        <div>
+          <input
+            list="cust-list"
+            className="border p-2 w-full"
+            placeholder="Cliente"
+            value={customerInput}
+            onChange={(e) => setCustomerInput(e.target.value)}
+            required
+          />
+          <datalist id="cust-list">
+            {customers.map((c) => (
+              <option key={c.id} value={c.trade_name} />
+            ))}
+          </datalist>
+        </div>
+        <select
+          className="border p-2 w-full"
+          value={serviceID}
+          onChange={(e) => setServiceID(e.target.value)}
+          required
+        >
+          <option value="" disabled>
+            Serviço...
+          </option>
+          {services.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.name}
+            </option>
+          ))}
+        </select>
+        <select
+          className="border p-2 w-full"
+          value={promoterID}
+          onChange={(e) => setPromoterID(e.target.value)}
+        >
+          <option value="">Promotor...</option>
+          {promoters.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+        <input
+          type="number"
+          min="0"
+          step="0.01"
+          className="border p-2 w-full"
+          placeholder="Valor"
+          value={valueTotal}
+          onChange={(e) => setValueTotal(parseFloat(e.target.value))}
+          required
+        />
+        <input
+          type="date"
+          className="border p-2 w-full"
+          value={startDate}
+          onChange={(e) => setStartDate(e.target.value)}
+          required
+        />
+        <input
+          type="date"
+          className="border p-2 w-full"
+          value={endDate}
+          onChange={(e) => setEndDate(e.target.value)}
+        />
+        <select
+          className="border p-2 w-full"
+          value={status}
+          onChange={(e) => setStatus(e.target.value)}
+        >
+          <option value="active">active</option>
+          <option value="suspended">suspended</option>
+          <option value="closed">closed</option>
+          <option value="cancelled">cancelled</option>
+        </select>
+      </div>
+      {contract && <Attachments contractId={contract.id} />}
+      {error && <p className="text-red-500 text-sm">{error}</p>}
+      <div className="flex gap-2 justify-end">
+        <button type="button" onClick={onClose} className="border px-4 py-2">
+          Cancelar
+        </button>
+        <button
+          type="submit"
+          className="bg-blue-500 text-white px-4 py-2"
+          disabled={loading}
+        >
+          {loading ? (
+            <div className="h-4 w-4 border-2 border-gray-300 border-t-transparent rounded-full animate-spin" />
+          ) : (
+            "Salvar"
+          )}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/app/contracts/page.tsx
+++ b/frontend/src/app/contracts/page.tsx
@@ -1,0 +1,149 @@
+"use client";
+import { useState, Fragment } from "react";
+import useSWR from "swr";
+import { Dialog, Transition } from "@headlessui/react";
+import ProtectedRoute from "@/components/ProtectedRoute";
+import Money from "@/components/Money";
+import Toast from "@/components/Toast";
+import { api } from "@/util/api";
+import ContractForm, { Contract } from "./ContractForm";
+import Attachments from "./Attachments";
+
+const fetcher = (url: string) => api<Contract[]>(url);
+
+export default function ContractsPage() {
+  const { data, isLoading, mutate } = useSWR(
+    "/contracts?status=active",
+    fetcher,
+  );
+  const [isFormOpen, setFormOpen] = useState(false);
+  const [editing, setEditing] = useState<Contract | null>(null);
+  const [attId, setAttId] = useState<string | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+
+  const closeForm = () => {
+    setFormOpen(false);
+    setEditing(null);
+  };
+  const openForNew = () => {
+    setEditing(null);
+    setFormOpen(true);
+  };
+  const openForEdit = (c: Contract) => {
+    setEditing(c);
+    setFormOpen(true);
+  };
+  const closeAtt = () => setAttId(null);
+
+  const handleDelete = async (id: string) => {
+    if (!confirm("Remover contrato?")) return;
+    try {
+      await api(`/contracts/${id}`, { method: "DELETE" });
+      setToast("Contrato removido");
+      mutate();
+    } catch {
+      setToast("Erro ao remover contrato");
+    } finally {
+      setTimeout(() => setToast(null), 3000);
+    }
+  };
+
+  const handleSuccess = () => {
+    mutate();
+    setToast("Contrato salvo");
+    setTimeout(() => setToast(null), 3000);
+    closeForm();
+  };
+
+  return (
+    <ProtectedRoute roles={["admin", "finance"]}>
+      <div className="p-4">
+        <div className="flex justify-between items-center mb-4">
+          <h1 className="text-xl font-bold">Contratos</h1>
+          <button onClick={openForNew} className="bg-blue-500 text-white px-4 py-2">
+            Novo Contrato
+          </button>
+        </div>
+        {isLoading ? (
+          <div className="flex justify-center p-4">
+            <div className="h-5 w-5 border-2 border-gray-300 border-t-transparent rounded-full animate-spin" />
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2 text-left">Cliente</th>
+                  <th className="px-4 py-2 text-left">Serviço</th>
+                  <th className="px-4 py-2 text-left">Valor</th>
+                  <th className="px-4 py-2 text-left">Início</th>
+                  <th className="px-4 py-2 text-left">Término</th>
+                  <th className="px-4 py-2 text-left">Status</th>
+                  <th className="px-4 py-2 text-left">Ações</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data?.map((c, idx) => (
+                  <tr key={c.id} className={idx % 2 ? "bg-gray-50" : "bg-white"}>
+                    <td className="px-4 py-2">{c.customer?.trade_name}</td>
+                    <td className="px-4 py-2">{c.service?.name}</td>
+                    <td className="px-4 py-2">
+                      <Money value={c.value_total} />
+                    </td>
+                    <td className="px-4 py-2">
+                      {new Date(c.start_date).toLocaleDateString()}
+                    </td>
+                    <td className="px-4 py-2">
+                      {c.end_date ? new Date(c.end_date).toLocaleDateString() : ""}
+                    </td>
+                    <td className="px-4 py-2">{c.status}</td>
+                    <td className="px-4 py-2 space-x-2">
+                      <button onClick={() => openForEdit(c)}>✏️</button>
+                      <button onClick={() => setAttId(c.id)}>📎</button>
+                      <button onClick={() => handleDelete(c.id)}>🗑</button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+        <Transition appear show={isFormOpen} as={Fragment}>
+          <Dialog as="div" className="fixed inset-0 z-10 overflow-y-auto" onClose={closeForm}>
+            <div className="min-h-screen px-4 text-center">
+              <Transition.Child as={Fragment} enter="ease-out duration-300" enterFrom="opacity-0" enterTo="opacity-100" leave="ease-in duration-200" leaveFrom="opacity-100" leaveTo="opacity-0">
+                <div className="fixed inset-0 bg-black/50" />
+              </Transition.Child>
+              <span className="inline-block h-screen align-middle" aria-hidden="true">
+                &#8203;
+              </span>
+              <Transition.Child as={Fragment} enter="ease-out duration-300" enterFrom="opacity-0 scale-95" enterTo="opacity-100 scale-100" leave="ease-in duration-200" leaveFrom="opacity-100 scale-100" leaveTo="opacity-0 scale-95">
+                <div className="inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-xl">
+                  <ContractForm contract={editing || undefined} onClose={closeForm} onSuccess={handleSuccess} />
+                </div>
+              </Transition.Child>
+            </div>
+          </Dialog>
+        </Transition>
+        <Transition appear show={!!attId} as={Fragment}>
+          <Dialog as="div" className="fixed inset-0 z-10 overflow-y-auto" onClose={closeAtt}>
+            <div className="min-h-screen px-4 text-center">
+              <Transition.Child as={Fragment} enter="ease-out duration-300" enterFrom="opacity-0" enterTo="opacity-100" leave="ease-in duration-200" leaveFrom="opacity-100" leaveTo="opacity-0">
+                <div className="fixed inset-0 bg-black/50" />
+              </Transition.Child>
+              <span className="inline-block h-screen align-middle" aria-hidden="true">
+                &#8203;
+              </span>
+              <Transition.Child as={Fragment} enter="ease-out duration-300" enterFrom="opacity-0 scale-95" enterTo="opacity-100 scale-100" leave="ease-in duration-200" leaveFrom="opacity-100 scale-100" leaveTo="opacity-0 scale-95">
+                <div className="inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-xl">
+                  {attId && <Attachments contractId={attId} />}
+                </div>
+              </Transition.Child>
+            </div>
+          </Dialog>
+        </Transition>
+        <Toast message={toast} />
+      </div>
+    </ProtectedRoute>
+  );
+}

--- a/frontend/src/util/api.ts
+++ b/frontend/src/util/api.ts
@@ -17,4 +17,21 @@ export async function apiFetch<T = unknown>(
   return (await res.json()) as T;
 }
 
+export async function apiPresign(
+  path: string,
+  filename: string,
+): Promise<string> {
+  const token =
+    typeof window !== "undefined" ? localStorage.getItem("token") : null;
+  const headers: Record<string, string> = {};
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+  const res = await fetch(`${API_BASE}${path}?filename=${encodeURIComponent(filename)}`, {
+    method: "PUT",
+    headers,
+  });
+  if (!res.ok) throw new Error(await res.text());
+  const data = (await res.json()) as { url: string };
+  return data.url;
+}
+
 export { apiFetch as api };


### PR DESCRIPTION
## Summary
- add apiPresign helper
- implement contracts listing with create/edit and attachments
- create contract form with validation and attachments list
- support uploading contract attachments via presigned URLs

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685a16c88d88832b9b72771a607a8d07