### PR TITLE
Add MinIO backup stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,5 +3,7 @@ POSTGRES_PASSWORD=rgps_pass
 POSTGRES_DB=rgps_backoffice
 JWT_SECRET=changeme
 GEO_TIMEOUT_MS=5000
+MINIO_ACCESS_KEY=rgpsadmin
+MINIO_SECRET_KEY=rgpssecret
 MINIO_BUCKET=rgps-backup
 NEXT_PUBLIC_API_URL=rgps-backend

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Acesse:
 ## Backup
 docker-compose -f infra/backup.yml up -d
 
+Console MinIO: <http://localhost:9001> (rgpsadmin / rgpssecret)
+
 ---
 
 ## Estrutura de pastas

--- a/infra/backup.yml
+++ b/infra/backup.yml
@@ -13,7 +13,25 @@ services:
       - PGHOST=db
       - PGDATABASE=${POSTGRES_DB}
       - MINIO_BUCKET=${MINIO_BUCKET}
-      - MC_HOST_minio=http://minioadmin:minioadmin@minio:9000
+      - MC_HOST_minio=http://minioadmin:minioadmin@rgps-minio:9000
     depends_on:
       - db
+      - minio
     restart: unless-stopped
+
+  minio:
+    image: minio/minio:RELEASE.2024-05-10T02-44-02Z
+    container_name: rgps-minio
+    command: server /data --console-address ":9001"
+    environment:
+      - MINIO_ROOT_USER=${MINIO_ACCESS_KEY}
+      - MINIO_ROOT_PASSWORD=${MINIO_SECRET_KEY}
+    volumes:
+      - rgps_minio_data:/data
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    restart: unless-stopped
+
+volumes:
+  rgps_minio_data:

--- a/infra/backup/pg_dump.sh
+++ b/infra/backup/pg_dump.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+: ${MINIO_BUCKET:=rgps-backup}
+
 FILE="$(date +"%Y-%m-%d_%H%M").sql.gz"
 
 echo "[BackupAgent] starting pg_dump to /backup/$FILE"


### PR DESCRIPTION
## Summary
- update backup compose to include minio service
- set default bucket variable in backup script
- document minio usage and credentials
- update environment example for minio credentials

## Testing
- `gofmt -w backend`
- `docker-compose -f infra/backup.yml up -d --build` *(fails: docker-compose not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685a19934ca8832b8251eb2d415d01ce