### PR TITLE
Integrate audit middleware and logs endpoint

### DIFF
--- a/backend/internal/audit/geo.go
+++ b/backend/internal/audit/geo.go
@@ -23,22 +23,27 @@ type GeoService interface {
 
 // HttpGeoService implementa GeoService via chamada HTTP pública.
 type HttpGeoService struct {
-	client *http.Client
+	client  *http.Client
+	baseURL string
 }
 
 // NewHttpGeoService cria um HttpGeoService com timeout configurado.
-func NewHttpGeoService() *HttpGeoService {
+// Se baseURL for vazio, usa https://ipapi.co como provedor padrao.
+func NewHttpGeoService(baseURL string) *HttpGeoService {
 	timeout := 5 * time.Second
 	if v := os.Getenv("GEO_TIMEOUT_MS"); v != "" {
 		if ms, err := time.ParseDuration(v + "ms"); err == nil {
 			timeout = ms
 		}
 	}
-	return &HttpGeoService{client: &http.Client{Timeout: timeout}}
+	if baseURL == "" {
+		baseURL = "https://ipapi.co"
+	}
+	return &HttpGeoService{client: &http.Client{Timeout: timeout}, baseURL: baseURL}
 }
 
 func (h *HttpGeoService) Lookup(ctx context.Context, ip string) (GeoInfo, error) {
-	url := "https://ipapi.co/" + ip + "/json/"
+	url := h.baseURL + "/" + ip + "/json/"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return GeoInfo{}, err

--- a/backend/internal/auditquery/handler.go
+++ b/backend/internal/auditquery/handler.go
@@ -1,0 +1,60 @@
+package auditquery
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/rgomids/bckoffice/internal/auth"
+)
+
+// RegisterRoutes adiciona a rota de consulta de audit logs.
+func RegisterRoutes(r chi.Router, repo Repository) {
+	h := handler{repo: repo}
+	r.Route("/audit-logs", func(rt chi.Router) {
+		rt.Use(auth.RequireRole("admin"))
+		rt.Get("/", h.list)
+	})
+}
+
+type handler struct {
+	repo Repository
+}
+
+// @Summary Lista audit logs
+// @Tags audit
+// @Security BearerAuth
+// @Param entity query string false "Nome da entidade"
+// @Param action query string false "insert|update|delete"
+// @Success 200 {array} audit.AuditLog
+// @Router  /audit-logs [get]
+func (h handler) list(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	q := r.URL.Query()
+	limit, _ := strconv.Atoi(q.Get("limit"))
+	startStr := q.Get("start")
+	endStr := q.Get("end")
+	var start, end time.Time
+	if startStr != "" {
+		start, _ = time.Parse(time.RFC3339, startStr)
+	}
+	if endStr != "" {
+		end, _ = time.Parse(time.RFC3339, endStr)
+	}
+	filter := AuditFilter{
+		EntityName: q.Get("entity"),
+		UserID:     q.Get("user"),
+		Action:     q.Get("action"),
+		StartDate:  start,
+		EndDate:    end,
+		Limit:      limit,
+	}
+	logs, err := h.repo.List(r.Context(), filter)
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	_ = json.NewEncoder(w).Encode(logs)
+}

--- a/backend/internal/auditquery/handler_test.go
+++ b/backend/internal/auditquery/handler_test.go
@@ -1,0 +1,77 @@
+package auditquery
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/rgomids/bckoffice/internal/audit"
+	"github.com/rgomids/bckoffice/internal/auth"
+)
+
+type fakeRepo struct {
+	logs []audit.AuditLog
+}
+
+func (f *fakeRepo) List(ctx context.Context, fl AuditFilter) ([]audit.AuditLog, error) {
+	out := make([]audit.AuditLog, 0)
+	for _, l := range f.logs {
+		if fl.EntityName != "" && l.EntityName != fl.EntityName {
+			continue
+		}
+		if fl.Action != "" && l.Action != fl.Action {
+			continue
+		}
+		out = append(out, l)
+	}
+	if fl.Limit > 0 && len(out) > fl.Limit {
+		out = out[:fl.Limit]
+	}
+	return out, nil
+}
+
+func setupRouter(repo Repository, role string) (*chi.Mux, string) {
+	os.Setenv("JWT_SECRET", "testsecret")
+	claims := jwt.MapClaims{"sub": "u1", "role": role, "exp": time.Now().Add(time.Hour).Unix()}
+	token, _ := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte("testsecret"))
+
+	r := chi.NewRouter()
+	r.Use(auth.AuthMiddleware)
+	RegisterRoutes(r, repo)
+	return r, token
+}
+
+func TestListAuditLogsFilter(t *testing.T) {
+	repo := &fakeRepo{logs: []audit.AuditLog{
+		{ID: "1", EntityName: "customers", Action: "update"},
+		{ID: "2", EntityName: "services", Action: "insert"},
+	}}
+	r, token := setupRouter(repo, "admin")
+	server := httptest.NewServer(r)
+	defer server.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, server.URL+"/audit-logs?entity=customers&action=update&limit=1", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var out []audit.AuditLog
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out) != 1 || out[0].ID != "1" {
+		t.Fatalf("unexpected result: %+v", out)
+	}
+}

--- a/backend/internal/auditquery/postgres_repository.go
+++ b/backend/internal/auditquery/postgres_repository.go
@@ -1,0 +1,57 @@
+package auditquery
+
+import (
+	"context"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/rgomids/bckoffice/internal/audit"
+)
+
+// PostgresRepository implementa Repository usando PostgreSQL.
+type PostgresRepository struct {
+	db *sqlx.DB
+}
+
+// NewPostgresRepository cria uma instancia de PostgresRepository.
+func NewPostgresRepository(db *sqlx.DB) *PostgresRepository {
+	return &PostgresRepository{db: db}
+}
+
+func toNull(s string) interface{} {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+// List retorna os logs conforme filtros informados.
+func (r *PostgresRepository) List(ctx context.Context, f AuditFilter) ([]audit.AuditLog, error) {
+	logs := []audit.AuditLog{}
+	const q = `SELECT * FROM audit_logs
+        WHERE (entity_name=$1 OR $1 IS NULL)
+          AND (user_id=$2 OR $2 IS NULL)
+          AND (action=$3 OR $3 IS NULL)
+          AND created_at BETWEEN $4 AND $5
+        ORDER BY created_at DESC
+        LIMIT $6`
+	start := f.StartDate
+	if start.IsZero() {
+		start = time.Unix(0, 0)
+	}
+	end := f.EndDate
+	if end.IsZero() {
+		end = time.Now()
+	}
+	if f.Limit == 0 {
+		f.Limit = 100
+	}
+	if err := r.db.SelectContext(ctx, &logs, q,
+		toNull(f.EntityName), toNull(f.UserID), toNull(f.Action),
+		start, end, f.Limit); err != nil {
+		return nil, err
+	}
+	return logs, nil
+}
+
+var _ Repository = (*PostgresRepository)(nil)

--- a/backend/internal/auditquery/repository.go
+++ b/backend/internal/auditquery/repository.go
@@ -1,0 +1,23 @@
+package auditquery
+
+import (
+	"context"
+	"time"
+
+	"github.com/rgomids/bckoffice/internal/audit"
+)
+
+// AuditFilter define filtros para listagem de logs.
+type AuditFilter struct {
+	EntityName string
+	UserID     string
+	Action     string
+	StartDate  time.Time
+	EndDate    time.Time
+	Limit      int
+}
+
+// Repository define operacoes de consulta aos logs de auditoria.
+type Repository interface {
+	List(ctx context.Context, filter AuditFilter) ([]audit.AuditLog, error)
+}

--- a/backend/internal/contract/handler.go
+++ b/backend/internal/contract/handler.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -140,6 +141,7 @@ func (h handler) create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Location", "/contracts/"+c.ID)
+	w.Header().Set("X-Entity", fmt.Sprintf("contracts:%s", c.ID))
 	w.WriteHeader(http.StatusCreated)
 	_ = json.NewEncoder(w).Encode(c)
 }
@@ -203,6 +205,7 @@ func (h handler) update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.Header().Set("X-Entity", fmt.Sprintf("contracts:%s", id))
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -221,5 +224,6 @@ func (h handler) remove(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
+	w.Header().Set("X-Entity", fmt.Sprintf("contracts:%s", id))
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/backend/internal/customer/handler.go
+++ b/backend/internal/customer/handler.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -100,6 +101,7 @@ func (h handler) create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Location", "/customers/"+c.ID)
+	w.Header().Set("X-Entity", fmt.Sprintf("customers:%s", c.ID))
 	w.WriteHeader(http.StatusCreated)
 	_ = json.NewEncoder(w).Encode(c)
 }
@@ -170,6 +172,7 @@ func (h handler) update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.Header().Set("X-Entity", fmt.Sprintf("customers:%s", id))
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -188,5 +191,6 @@ func (h handler) remove(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
+	w.Header().Set("X-Entity", fmt.Sprintf("customers:%s", id))
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/backend/internal/finance/handler.go
+++ b/backend/internal/finance/handler.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -65,6 +66,7 @@ func (h handler) markAsPaid(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
+	w.Header().Set("X-Entity", fmt.Sprintf("receivables:%s", id))
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -105,5 +107,6 @@ func (h handler) approveCommission(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
+	w.Header().Set("X-Entity", fmt.Sprintf("commissions:%s", id))
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/backend/internal/lead/handler.go
+++ b/backend/internal/lead/handler.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -103,6 +104,7 @@ func (h handler) create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Location", "/leads/"+l.ID)
+	w.Header().Set("X-Entity", fmt.Sprintf("leads:%s", l.ID))
 	w.WriteHeader(http.StatusCreated)
 	_ = json.NewEncoder(w).Encode(l)
 }
@@ -139,6 +141,7 @@ func (h handler) updateStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.Header().Set("X-Entity", fmt.Sprintf("leads:%s", id))
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -179,6 +182,7 @@ func (h handler) update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.Header().Set("X-Entity", fmt.Sprintf("leads:%s", id))
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -197,5 +201,6 @@ func (h handler) remove(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
+	w.Header().Set("X-Entity", fmt.Sprintf("leads:%s", id))
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/backend/internal/promoter/handler.go
+++ b/backend/internal/promoter/handler.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -94,6 +95,7 @@ func (h handler) create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Location", "/promoters/"+p.ID)
+	w.Header().Set("X-Entity", fmt.Sprintf("promoters:%s", p.ID))
 	w.WriteHeader(http.StatusCreated)
 	_ = json.NewEncoder(w).Encode(p)
 }
@@ -138,6 +140,7 @@ func (h handler) update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.Header().Set("X-Entity", fmt.Sprintf("promoters:%s", id))
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -156,5 +159,6 @@ func (h handler) remove(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
+	w.Header().Set("X-Entity", fmt.Sprintf("promoters:%s", id))
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/backend/internal/service/handler.go
+++ b/backend/internal/service/handler.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -91,6 +92,7 @@ func (h handler) create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Location", "/services/"+s.ID)
+	w.Header().Set("X-Entity", fmt.Sprintf("services:%s", s.ID))
 	w.WriteHeader(http.StatusCreated)
 	_ = json.NewEncoder(w).Encode(s)
 }
@@ -134,6 +136,7 @@ func (h handler) update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.Header().Set("X-Entity", fmt.Sprintf("services:%s", id))
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -152,5 +155,6 @@ func (h handler) remove(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
+	w.Header().Set("X-Entity", fmt.Sprintf("services:%s", id))
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/frontend/src/app/audit-logs/page.tsx
+++ b/frontend/src/app/audit-logs/page.tsx
@@ -1,0 +1,39 @@
+"use client";
+import useSWR from "swr";
+import Link from "next/link";
+import ProtectedRoute from "@/components/ProtectedRoute";
+import { api } from "@/util/api";
+
+interface AuditLog {
+  id: string;
+  entityName: string;
+  entityId: string;
+  action: string;
+  createdAt: string;
+  userId: string;
+}
+
+const fetcher = (url: string) => api<AuditLog[]>(url);
+
+export default function AuditLogsPage() {
+  const { data } = useSWR("/audit-logs?limit=50", fetcher);
+  return (
+    <ProtectedRoute roles={["admin"]}>
+      <div className="p-4 space-y-2">
+        <Link href="/dashboard" className="text-blue-600 hover:underline">
+          Voltar
+        </Link>
+        <h1 className="text-xl font-bold">Audit Logs</h1>
+        {data ? (
+          <div className="space-y-1 font-mono text-sm">
+            {data.map((l) => (
+              <div key={l.id}>{JSON.stringify(l)}</div>
+            ))}
+          </div>
+        ) : (
+          <div>Carregando...</div>
+        )}
+      </div>
+    </ProtectedRoute>
+  );
+}

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,9 +1,31 @@
+"use client";
 import ProtectedRoute from "@/components/ProtectedRoute";
+import Link from "next/link";
+import { getToken } from "@/hooks/useAuth";
+
+function getRole(): string | null {
+  const token = getToken();
+  if (!token) return null;
+  try {
+    const payload = JSON.parse(atob(token.split(".")[1]));
+    return payload.role || null;
+  } catch {
+    return null;
+  }
+}
 
 export default function DashboardPage() {
+  const role = getRole();
   return (
     <ProtectedRoute>
-      <div className="p-4">Dashboard</div>
+      <div className="p-4 space-y-2">
+        <div>Dashboard</div>
+        {role === "admin" && (
+          <Link href="/audit-logs" className="text-blue-600 hover:underline">
+            Audit Logs
+          </Link>
+        )}
+      </div>
     </ProtectedRoute>
   );
 }


### PR DESCRIPTION
## Summary
- hook global audit middleware
- expose audit log query API and repository
- collect entity info in mutating handlers
- show Audit Logs link for admins
- stub audit logs page
- add unit tests for audit query

## Testing
- `go vet ./...`
- `go test ./internal/auditquery -v`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685a1a98b464832ba2718838fa9d4a50